### PR TITLE
Default to https instead of git protocol for dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,8 @@
     "d3": "^3.4.12",
     "heap": "^0.2.4",
     "numericjs": "^1.2.6",
-    "simplify-js": "git@github.com:mourner/simplify-js.git",
-    "static-kdtree": "git@github.com:mikolalysenko/static-kdtree.git#ce6e639c333fbab310fa44a3587b4bfdf10dbd4b",
+    "simplify-js": "https://github.com/mourner/simplify-js.git",
+    "static-kdtree": "https://github.com/mikolalysenko/static-kdtree.git",
     "topojson": "^1.6.18"
   },
   "devDependencies": {


### PR DESCRIPTION
If a company is behind a firewall that doesn't permit git, or the user hasn't set up SSH yet, they'll have to hunt down this guy:
http://stackoverflow.com/questions/15669091/bower-install-using-only-https/15684898#15684898

Bower may be protocol agnostic, but seems like a best practice is to link to https.
