### PR TITLE
Fix loop to insert data values into CSV

### DIFF
--- a/src/viz/methods/csv.coffee
+++ b/src/viz/methods/csv.coffee
@@ -37,7 +37,7 @@ module.exports =
       titles.push vars.format.value(c)
 
     csv_to_return.push titles
-    for n in vars.returned.nodes.forEach
+    for n in vars.returned.nodes
       arr = []
       for c in columns
         arr.push fetchValue(vars, n, c)


### PR DESCRIPTION
When using the .csv() method, the output only has headers. It looks like the loop that adds the data had an issue with an extra .forEach call.