### PR TITLE
Fixing issue where title would show up as 'undefined', and trimming filenames that are too long.

### DIFF
--- a/src/viz/methods/csv.coffee
+++ b/src/viz/methods/csv.coffee
@@ -21,9 +21,11 @@ module.exports =
     titles        = []
 
     if vars.title.value
-      title = vars.title.string
+      title = vars.title.value
       title = title(vars.self) if typeof title is "function"
       title = stringStrip title
+      max_filename_len = 250
+      title = title.substr(0, max_filename_len)
     else
       title = "D3plus Visualization Data"
 


### PR DESCRIPTION
Fixes an issue where title would become "undefined" and does a truncation to make sure that filename (with ".csv" extension) is less than 255 characters, which is a [common limit on modern OS filesystems](http://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits) 

This commit fixes issues with DataViva/dataviva-site#174 and DataViva/dataviva-site#253