### PR TITLE
added coffeefiy entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "type": "git",
     "url": "https://github.com/alexandersimoes/d3plus.git"
   },
+  "browserify": {
+    "transform": ["coffeeify"]
+  },
   "keywords": [
     "charts",
     "d3",


### PR DESCRIPTION
Would you consider accepting this Pull Request which makes d3plus more consumable to users of browserify? Placing the transforms necessary to the bundle process in the package.json frees us from keeping track of all these transforms in a central configuration file, and makes the module more generically usable to anyone wanting to plug it into their browserify-based build system.