### PR TITLE
Stop using `x` and `dx` attributes on `tspan`s together

### DIFF
--- a/src/textwrap/helpers/tspan.coffee
+++ b/src/textwrap/helpers/tspan.coffee
@@ -13,7 +13,6 @@ module.exports = (vars) ->
 
     tspan
       .attr "x", x + "px"
-      .attr "dx", dx + "px"
       .attr "dy", dy + "px"
       .style "baseline-shift", "0%"
       .attr "dominant-baseline", "alphabetic"
@@ -28,14 +27,14 @@ module.exports = (vars) ->
     anchor = vars.align.value or vars.container.align or "start"
 
   if anchor is "end" or (anchor is "start" and rtl)
-    dx = width
+    xOffset = width
   else if anchor is "middle"
-    dx = width/2
+    xOffset = width/2
   else
-    dx = 0
+    xOffset = 0
 
   valign   = vars.valign.value or "top"
-  x        = vars.container.x
+  x        = vars.container.x + xOffset
   fontSize = if vars.resize.value then vars.size.value[1] else vars.container.fontSize or vars.size.value[0]
   dy       = vars.container.dy or fontSize * 1.1
   textBox  = null


### PR DESCRIPTION
Fixes #402.

I’ve tested it on the [Tree Map example](http://d3plus.org/examples/basic/9029130/). Have tried to test it [on other examples](https://github.com/alexandersimoes/d3plus/wiki#visualizations) as well, but it appears they are broken when using d3plus built from the latest sources.

Looking forward to your comments.