### PR TITLE
Add the gulp task to run the server

### DIFF
--- a/gulp/dev.coffee
+++ b/gulp/dev.coffee
@@ -11,10 +11,11 @@ watchify   = require "watchify"
 
 test_dir = "./tests/**/*.*"
 
-connect.server
-  livereload: true
-  port: 4000
-  root: path.resolve("./")
+gulp.task "server", ->
+  connect.server
+    livereload: true
+    port: 4000
+    root: path.resolve("./")
 
 rebundle = ->
   bundler.bundle()

--- a/gulp/dev.coffee
+++ b/gulp/dev.coffee
@@ -11,10 +11,10 @@ watchify   = require "watchify"
 
 test_dir = "./tests/**/*.*"
 
-# connect.server
-#   livereload: false
-#   port: 4000
-#   root: path.resolve("./")
+connect.server
+  livereload: true
+  port: 4000
+  root: path.resolve("./")
 
 rebundle = ->
   bundler.bundle()
@@ -27,7 +27,7 @@ rebundle = ->
       message: "New Build Compiled"
       icon:    __dirname + "/../icon.png"
     ))
-    # .pipe connect.reload()
+    .pipe connect.reload()
     .on "error", notify.onError(error)
 
 bundler = watchify(browserify(watchify.args))
@@ -43,4 +43,4 @@ gulp.task "dev", ->
     fileName = path.relative("./", file.path)
     gutil.log gutil.colors.cyan(fileName), "changed"
 
-    # gulp.src(test_dir).pipe connect.reload()
+    gulp.src(test_dir).pipe connect.reload()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,6 @@ var gulp = require("gulp");
 require('coffee-script/register');
 require("require-dir")("./gulp");
 
-gulp.task("default", ["dev"]);
+gulp.task("default", ["server", "dev"]);
 
 gulp.task("release", ["compile", "docs"], function() { process.exit(); });


### PR DESCRIPTION
Readme mentions:

> Gulp will run a server on your local machine at port 4000

However, the server was _temporarily_ disabled by 8ef5cd2 in August :–)

I moved the server setup to separate `"server"` task. This allows us to prevent the server from starting when building a release.

Looking forward to your comments. Feel free to decline the PR if the server still needs to be disabled.