### PR TITLE
sort axis tick numbers in numeric order

### DIFF
--- a/src/viz/types/helpers/graph/includes/axes.coffee
+++ b/src/viz/types/helpers/graph/includes/axes.coffee
@@ -180,7 +180,7 @@ axisRange = (vars, axis, zero, buffer) ->
         , []
         counts
       else
-        uniques(values).sort()
+        uniques(values).sort((a,b) -> a-b)
     else
       values.sort (a, b) -> a - b
       if vars[axis].scale.value is "log"


### PR DESCRIPTION
Array.sort sorts in alphabetical order by default, and the visual gets corrupted. This happens with values like [0,1,2,3,4,5,6,7,8,9,10,11].sort()