### PR TITLE
Make the Legend Tooltip (short mode) have a configurable max list length

### DIFF
--- a/src/viz/helpers/tooltip/create.js
+++ b/src/viz/helpers/tooltip/create.js
@@ -159,7 +159,8 @@ module.exports = function(params) {
 
       }
 
-      var limit = length === "short" ? 3 : vars.data.large,
+      var maxChildrenShownInShortMode = vars.tooltip.children.value === true ? 3 : vars.tooltip.children.value;
+      var limit = length === "short" ? maxChildrenShownInShortMode : vars.data.large,
           listLength = nameList.length,
           max   = d3.min([listLength , limit]),
           objs  = [];

--- a/src/viz/methods/tooltip.coffee
+++ b/src/viz/methods/tooltip.coffee
@@ -6,7 +6,7 @@ module.exports =
   anchor:     "top center"
   background: "#ffffff"
   children:
-    accepted: [Boolean]
+    accepted: [Boolean, Number]
     value:    true
   connections:
     accepted: [Boolean]


### PR DESCRIPTION
Currently the legend tooltip (short mode) will limit the number of items shown to a maximum of 3, which is hard coded.

This change exposes that limit to d3plus applications