### PR TITLE
fixes back button appearance according to .history() value

### DIFF
--- a/src/viz/helpers/ui/history.coffee
+++ b/src/viz/helpers/ui/history.coffee
@@ -6,7 +6,7 @@ stylesheet = require "../../../client/css.coffee"
 # Creates "back" button, if applicable
 module.exports = (vars) ->
 
-  if !vars.small and vars.history.states.length > 0
+  if !vars.small and vars.history.value and vars.history.states.length > 0
 
     print.time "drawing back button" if vars.dev.value
 


### PR DESCRIPTION
Just added another `if` statement which checks if `vars.history.value` is set to `true` and should draw the back button. Tested for the same type of viz mentioned in the issue.

Fixes #543 