### PR TITLE
correct variable scope to support size adjustment

### DIFF
--- a/packages/dom/src/getSize.js
+++ b/packages/dom/src/getSize.js
@@ -30,7 +30,7 @@ function _elementSize(element, s) {
 
   }
   else {
-    const val = parseFloat(select(element).style(s), 10);
+    let val = parseFloat(select(element).style(s), 10);
     if (typeof val === "number" && val > 0) {
       if (s === "height") {
         val -= parseFloat(select(element).style("padding-top"), 10);


### PR DESCRIPTION
## PR Summary
This small PR fixes a bug in `getSize.js` by replacing a `const` declaration with `let` for the variable `val`, allowing its value to be mutated during size calculation. The change is necessary to adjust the size by subtracting padding values.

Thanks for this library!