### PR TITLE
ci: retry Playwright install steps on transient failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,26 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      # Both Playwright install steps hit the network / apt and flake
+      # intermittently on the runners (install-deps has exited 100 mid-release),
+      # so retry each a few times before failing the job.
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @d3plus/core exec playwright install chromium
+        run: |
+          n=0
+          until pnpm --filter @d3plus/core exec playwright install chromium; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then echo "playwright install chromium failed after $n attempts"; exit 1; fi
+            echo "playwright install chromium failed (attempt $n); retrying in 15s..."; sleep 15
+          done
       - name: Install Playwright system dependencies
-        run: pnpm --filter @d3plus/core exec playwright install-deps chromium
+        run: |
+          n=0
+          until pnpm --filter @d3plus/core exec playwright install-deps chromium; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then echo "playwright install-deps chromium failed after $n attempts"; exit 1; fi
+            echo "playwright install-deps chromium failed (attempt $n); retrying in 15s..."; sleep 15
+          done
       - run: pnpm test
       - name: Typecheck (build types)
         run: pnpm -r --if-present run build:types


### PR DESCRIPTION
### What

Wrap the two Playwright install steps (`playwright install chromium` and `playwright install-deps chromium`) in a 3-attempt retry with a 15s backoff.

### Why

The v4.0.0 release commit's CI run failed at **Install Playwright system dependencies** — `playwright install-deps chromium` exited with code 100, a transient `apt` failure on the runner. The merge commit passed the same step minutes earlier and a plain re-run went green, so nothing was actually broken. These steps hit the network/apt on every run and flake intermittently; retrying absorbs the blip instead of reddening `main`.

### Notes

- Uses `until … done` with an explicit 3-attempt cap; verified under Actions' `set -eo pipefail` that a genuine failure still fails the job after the retries are exhausted, a success on any attempt exits cleanly, and the happy path adds no overhead.
- No change to what's installed, built, or tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XojqX18QxpnbE4VkQC9jeg
