### PR TITLE
fix(types): make D3plusConfig accessor types accurate, pass viz to toggles

### DIFF
--- a/packages/core/src/charts/events/click.legend.ts
+++ b/packages/core/src/charts/events/click.legend.ts
@@ -29,7 +29,7 @@ export default function (
     }),
   ).length;
 
-  const inverted = this.schema.legendFilterInvert.bind(this)();
+  const inverted = this.schema.legendFilterInvert.bind(this)(this);
 
   if (inverted) {
     if (event.shiftKey) {

--- a/packages/core/src/charts/events/mousemove.legend.ts
+++ b/packages/core/src/charts/events/mousemove.legend.ts
@@ -63,7 +63,7 @@ export default function (
       hasUserClick || (hasDefaultClick && hasDeeperLevel) ? "pointer" : "auto",
     );
 
-    const invertedBehavior = this.schema.legendFilterInvert.bind(this)();
+    const invertedBehavior = this.schema.legendFilterInvert.bind(this)(this);
 
     const solo = this._solo.includes(id);
     const hidden = this._hidden.includes(id);

--- a/packages/core/src/charts/features/features.ts
+++ b/packages/core/src/charts/features/features.ts
@@ -214,7 +214,7 @@ function textBlockLayout(
   const text = opts.getText(viz);
   if (!text) return {panel: null, margin: {}};
 
-  const usesPadding = (viz.schema[opts.paddingMethod] as () => boolean)();
+  const usesPadding = (viz.schema[opts.paddingMethod] as (viz: VizInstance) => boolean)(viz);
   const padding = usesPadding
     ? viz._padding
     : {top: 0, right: 0, bottom: 0, left: 0};
@@ -411,7 +411,7 @@ export const timelineFeature: FeatureModule = {
         : []
     ) as Date[];
     timelinePossible = timelinePossible && ticks.length > 1;
-    const padding = viz.schema.timelinePadding()
+    const padding = viz.schema.timelinePadding(viz)
       ? viz._padding
       : {top: 0, right: 0, bottom: 0, left: 0};
 
@@ -527,7 +527,7 @@ export const colorScaleFeature: FeatureModule = {
     const position = sanitizePosition(viz.schema.colorScalePosition.bind(viz)(resolveSpec(viz)));
     const wide = ["top", "bottom"].includes(position as string);
     const showColorScale = viz.schema.colorScale && position;
-    const padding = viz.schema.colorScalePadding()
+    const padding = viz.schema.colorScalePadding(viz)
       ? viz._padding
       : {top: 0, right: 0, bottom: 0, left: 0};
 

--- a/packages/core/src/charts/features/featuresLegend.ts
+++ b/packages/core/src/charts/features/featuresLegend.ts
@@ -126,7 +126,7 @@ function renderLegendFeature(
   const config = resolveSpec(viz);
   const position = sanitizePosition(viz.schema.legendPosition.bind(viz)(config));
   const wide = ["top", "bottom"].includes(position as string);
-  const padding = viz.schema.legendPadding()
+  const padding = viz.schema.legendPadding(viz)
     ? viz._padding
     : {top: 0, right: 0, bottom: 0, left: 0};
   const transform = {

--- a/packages/core/src/charts/viz/VizBase.ts
+++ b/packages/core/src/charts/viz/VizBase.ts
@@ -142,8 +142,8 @@ export default class VizBase extends VizBaseConfig {
       Tells the subtitle whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the subtitle appears centered above the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   subtitlePadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.subtitlePadding = typeof _ === "function" ? _ : constant(_)),
         this)
@@ -266,8 +266,8 @@ export default class VizBase extends VizBaseConfig {
       Tells the timeline whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the timeline appears centered underneath the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   timelinePadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.timelinePadding = typeof _ === "function" ? _ : constant(_)),
         this)
@@ -298,8 +298,8 @@ export default class VizBase extends VizBaseConfig {
       Tells the title whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the title appears centered above the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   titlePadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.titlePadding = typeof _ === "function" ? _ : constant(_)), this)
       : this.schema.titlePadding;
@@ -361,8 +361,8 @@ export default class VizBase extends VizBaseConfig {
       Tells the total whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the total appears centered above the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   totalPadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.totalPadding = typeof _ === "function" ? _ : constant(_)), this)
       : this.schema.totalPadding;

--- a/packages/core/src/charts/viz/VizBaseConfig.ts
+++ b/packages/core/src/charts/viz/VizBaseConfig.ts
@@ -6,6 +6,7 @@ import {fontFamilyStringify} from "@d3plus/text";
 import type {DataPoint} from "@d3plus/data";
 
 import {accessor, BaseClass, constant} from "../../utils/index.js";
+import type VizBase from "./VizBase.js";
 
 /**
     First half of the fluent config accessors shared by every Viz chart
@@ -131,8 +132,8 @@ export default class VizBaseConfig extends BaseClass {
       Tells the colorScale whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the colorScale appears centered above the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   colorScalePadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.colorScalePadding = typeof _ === "function" ? _ : constant(_)),
         this)
@@ -465,8 +466,8 @@ Defaults to an empty array (`[]`).
       Defines the click functionality of categorical legend squares. When set to false, clicking will hide that category and shift+clicking will solo that category. When set to true, clicking with solo that category and shift+clicking will hide that category.
 */
   legendFilterInvert(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.legendFilterInvert = typeof _ === "function" ? _ : constant(_)),
         this)
@@ -477,8 +478,8 @@ Defaults to an empty array (`[]`).
       Tells the legend whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the legend appears centered underneath the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
 */
   legendPadding(
-    _?: boolean | (() => boolean),
-  ): this | boolean | (() => boolean) {
+    _?: boolean | ((viz: VizBase) => boolean),
+  ): this | boolean | ((viz: VizBase) => boolean) {
     return arguments.length
       ? ((this.schema.legendPadding = typeof _ === "function" ? _ : constant(_)),
         this)

--- a/packages/core/src/utils/D3plusConfig.ts
+++ b/packages/core/src/utils/D3plusConfig.ts
@@ -1,5 +1,6 @@
 import type {DataPoint} from "@d3plus/data";
 
+import type VizBase from "../charts/viz/VizBase.js";
 import type {AccessorFn} from "./AccessorFn.js";
 
 type Position = "top" | "right" | "bottom" | "left";
@@ -272,8 +273,10 @@ export interface D3plusConfig {
     colorMax?: string;
     scale?: AxisScale;
   };
-  /** Position of the color scale, or false to hide it. */
-  colorScalePosition?: false | Position;
+  /** Whether the color scale uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  colorScalePadding?: boolean | ((viz: VizBase) => boolean);
+  /** Position of the color scale, `false` to hide it, or an accessor returning either. */
+  colorScalePosition?: false | Position | (() => false | Position);
   /** Column key for matrix-style layouts. */
   column?: string;
   /**
@@ -312,21 +315,34 @@ export interface D3plusConfig {
   groupPadding?: number;
   /** Overall height of the visualization in pixels. */
   height?: number;
+  /** Color for legend shapes whose grouping is hidden (via legend click), or a `(datum, index)` accessor. */
+  hiddenColor?: string | ((d: DataPoint, i: number) => string);
+  /** Opacity for legend labels whose grouping is hidden (via legend click), or a `(datum, index)` accessor. */
+  hiddenOpacity?: number | ((d: DataPoint, i: number) => number);
   /** The hover callback function for highlighting shapes on mouseover. */
   hover?: ((d: DataPoint, i: number) => boolean) | false | null;
   /** Persistently emphasizes matching marks (keep color) and grays the rest. */
   highlight?: ((d: DataPoint, i: number) => boolean) | false | null;
   /** Label accessor for shapes. */
   label?: string | string[] | false | AccessorFn;
-  /** Whether to show the legend. */
-  legend?: boolean;
+  /**
+      Controls legend visibility. Pass `false` to hide it, `true` to always
+      show it, or a `(config, data) => boolean` accessor to decide dynamically
+      — the chart defaults use an accessor to auto-hide the legend when it
+      would be redundant.
+  */
+  legend?: boolean | ((config: D3plusConfig, arr: DataPoint[]) => boolean);
   /** Configuration for the legend component. */
   legendConfig?: {
     label?: DataPointAccessor<string>;
     shapeConfig?: Record<string, string | number>;
   };
-  /** Position of the legend. */
-  legendPosition?: Position;
+  /** Inverts legend click behavior (click hides / shift-click solos, or the reverse), or an accessor receiving the viz. */
+  legendFilterInvert?: boolean | ((viz: VizBase) => boolean);
+  /** Whether the legend uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  legendPadding?: boolean | ((viz: VizBase) => boolean);
+  /** Position of the legend, or an accessor returning it. */
+  legendPosition?: Position | (() => Position);
   /** Custom sort comparator for legend items. */
   legendSort?: (a: DataPoint, b: DataPoint) => number;
   /** Tooltip configuration for legend items. */
@@ -335,10 +351,12 @@ export interface D3plusConfig {
   lineLabels?: boolean;
   /** Whether to show the loading message. */
   loadingMessage?: boolean;
-  /** Custom HTML content for the loading indicator. */
-  loadingHTML?: string;
+  /** Custom HTML content for the loading indicator, or a function receiving the viz instance. */
+  loadingHTML?: string | ((viz: VizBase) => string);
   /** Metric key for the visualization. */
   metric?: string;
+  /** Custom HTML content shown when no data is supplied, or a function receiving the viz instance. */
+  noDataHTML?: string | ((viz: VizBase) => string);
   /** Ocean color for geomaps (any CSS value including 'transparent'). */
   ocean?: string;
   /** Event listeners keyed by event name. */
@@ -379,6 +397,10 @@ export interface D3plusConfig {
   stacked?: boolean;
   /** Custom order for stacked series. */
   stackOrder?: string[];
+  /** Subtitle text, or an accessor returning it. */
+  subtitle?: string | ((data: DataPoint[]) => string);
+  /** Whether the subtitle uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  subtitlePadding?: boolean | ((viz: VizBase) => boolean);
   /** Value accessor for treemaps and aggregation. */
   sum?: DataPointAccessor<number>;
   /** Accessible description applied to the root SVG (`<desc>`). */
@@ -387,8 +409,8 @@ export interface D3plusConfig {
   svgTitle?: string;
   /** Threshold value for grouping small slices. */
   threshold?: number;
-  /** Label for the threshold group. */
-  thresholdName?: string;
+  /** Label for the threshold group, or a `(datum, index)` accessor. */
+  thresholdName?: string | ((d: DataPoint, i: number) => string);
   /** URL to XYZ map tiles. */
   tileUrl?: string;
   /** Whether to show map tiles. */
@@ -399,12 +421,16 @@ export interface D3plusConfig {
   timeFilter?: ((d: DataPoint, i: number) => boolean) | false;
   /** Whether to show the timeline component. */
   timeline?: boolean;
+  /** Whether the timeline uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  timelinePadding?: boolean | ((viz: VizBase) => boolean);
   /** Chart title or title accessor function. */
   title?: string | ((data: DataPoint[]) => string);
   /** CSS style configuration for the title. */
   titleConfig?: Record<string, string | number>;
-  /** Whether to show tooltips. */
-  tooltip?: boolean;
+  /** Whether the title uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  titlePadding?: boolean | ((viz: VizBase) => boolean);
+  /** Whether to show tooltips, or a `(datum, index)` accessor deciding per mark. */
+  tooltip?: boolean | ((d: DataPoint, i: number) => boolean);
   /** Configuration for the tooltip component. */
   tooltipConfig?: TooltipConfig;
   /** Path or object for the topojson data. */
@@ -413,6 +439,8 @@ export interface D3plusConfig {
   topojsonFill?: string;
   /** Accessor function for topojson feature IDs. */
   topojsonId?: (obj: Record<string, unknown>) => string;
+  /** Whether the total uses the visualization's internal padding when positioning, or an accessor receiving the viz. */
+  totalPadding?: boolean | ((viz: VizBase) => boolean);
   /** Value accessor for the visualization. */
   value?: DataPointAccessor<number>;
   /** Overall width of the visualization in pixels. */


### PR DESCRIPTION
### Config options now accept accessor functions

- `.config({ ... })` and the matching setters now type-check when given a function for options that were previously typed as constants only: `legend`, `tooltip`, `legendPosition`, `colorScalePosition`, `thresholdName`, and `loadingHTML`. These already worked at runtime — the chart defaults themselves store accessor functions — but the public type rejected them.

### Previously-missing config options are now typed

- Options that have working setters but were absent from the `D3plusConfig` type are now included, each accepting its constant or accessor form: `colorScalePadding`, `hiddenColor`, `hiddenOpacity`, `legendFilterInvert`, `legendPadding`, `noDataHTML`, `subtitle`, `subtitlePadding`, `timelinePadding`, `titlePadding`, `totalPadding`. Setting any of these through a config object or its setter now type-checks.

### Toggle accessors receive the visualization instance

- The boolean toggle options — the six `*Padding` fields and `legendFilterInvert` — now pass the viz instance to accessor functions, e.g. `.legendPadding(viz => viz.width() > 600)`. Previously these functions were called with no arguments, so they could not inspect the chart. Plain boolean values and existing zero-argument callbacks are unaffected.
