### PR TITLE
ci: drop EOL Node 20, test on 22/24, canary 26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,21 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    # Node 26 is still "Current" (LTS begins 2026-10-28), so run it as a
+    # forward-compat canary that reports but doesn't block merges when a
+    # bleeding-edge dependency lags. The supported LTS lines (22, 24) block.
+    continue-on-error: ${{ matrix.node-version == '26.x' }}
     env:
       FORCE_COLOR: "1"
 
     strategy:
+      # Report every version's result instead of cancelling the rest when one
+      # leg fails.
+      fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        # 22 (Jod) and 24 (Krypton) are Active LTS; 20 (Iron) went EOL
+        # 2026-04-30. 26 is the current release (canary, see continue-on-error).
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-color.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "browser": "./umd/d3plus-core.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-data.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-dom.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-export.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-format.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-locales.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-math.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-render.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -13,7 +13,7 @@
   },
   "browser": "./umd/d3plus-text.full.js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
## What

Modernizes the CI Node.js version matrix against the [official release schedule](https://github.com/nodejs/Release), and raises the packages' `engines` floor to match.

| Version | Status (2026-07) | In matrix |
|---|---|---|
| 20 (Iron) | **EOL** 2026-04-30 | ❌ removed |
| 22 (Jod) | Active LTS | ✅ blocking |
| 24 (Krypton) | Active LTS | ✅ blocking |
| 26 | Current (LTS 2026-10-28) | ⚠️ canary (non-blocking) |

- **Removed Node 20** — EOL 2026-04-30.
- **Added Node 24** — Active LTS; a supported target that must pass.
- **Added Node 26** as a non-blocking forward-compat canary (`continue-on-error`) — it's the current release, LTS begins Oct 28. Flip to blocking once it goes LTS.
- **`fail-fast: false`** so one version's failure doesn't cancel the others.
- **`engines` raised `>=20` → `>=22`** across all 12 packages, aligning the declared floor with what CI tests.

Coverage / Storybook / codecov steps stay gated on `22.x` (still in the matrix), so they run exactly once — unchanged.

## Notes

- **Branch protection updated**: required status checks changed from `test (20.x)` + `test (22.x)` to **`test (22.x)` + `test (24.x)`** (26 stays non-required as the canary).
- **Node 26 canary — investigated & resolved**: the first run's `test (26.x)` failed on a 2 s timeout in `packages/dom/test/fontExists-test.js`. Traced it to the native `canvas` optional dependency (jsdom's `measureText` backend) not yet having a Node 26 binary available at install time — an ecosystem lag for the days-old Node 26 release, not a d3plus bug. A clean-room Linux/Node 26 repro (Intl.Segmenter, canvas `measureText`, pretext all measured) showed no slowdown, and the canary **now passes** on a re-run. This is exactly what the non-blocking canary is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XojqX18QxpnbE4VkQC9jeg
