### PR TITLE
fix: keep schema.legend/shape/label callable for primitive args

### DIFF
--- a/packages/core/src/charts/AreaPlot/index.ts
+++ b/packages/core/src/charts/AreaPlot/index.ts
@@ -18,7 +18,7 @@ export const areaPlotDef: ChartDefinition = {
   fields: [
     {key: "baseline", default: 0},
     {key: "discrete", default: "x"},
-    {key: "shape", default: constant("Area")},
+    {key: "shape", default: constant("Area"), coerce: "const"},
   ],
 };
 

--- a/packages/core/src/charts/BarChart/index.ts
+++ b/packages/core/src/charts/BarChart/index.ts
@@ -21,9 +21,10 @@ export const barChartDef: ChartDefinition = {
   fields: [
     {key: "baseline", default: 0},
     {key: "discrete", default: "x"},
-    {key: "shape", default: constant("Bar")},
+    {key: "shape", default: constant("Bar"), coerce: "const"},
     {
       key: "legend",
+      coerce: "const",
       factory: (viz: VizInstance) => {
         const base = viz.schema.legend as (
           config: VizInstance,

--- a/packages/core/src/charts/BoxWhisker/index.ts
+++ b/packages/core/src/charts/BoxWhisker/index.ts
@@ -21,7 +21,7 @@ export const boxWhiskerDef: ChartDefinition = {
 
   fields: [
     {key: "discrete", default: "x"},
-    {key: "shape", default: constant("Box")},
+    {key: "shape", default: constant("Box"), coerce: "const"},
     {
       key: "tooltipConfig",
       merge: true,

--- a/packages/core/src/charts/BumpChart/index.ts
+++ b/packages/core/src/charts/BumpChart/index.ts
@@ -65,7 +65,7 @@ export const bumpChartDef: ChartDefinition = {
 
   fields: [
     {key: "discrete", default: "x"},
-    {key: "shape", default: constant("Line")},
+    {key: "shape", default: constant("Line"), coerce: "const"},
   ],
 };
 

--- a/packages/core/src/charts/Geomap/index.ts
+++ b/packages/core/src/charts/Geomap/index.ts
@@ -383,7 +383,7 @@ export const geomapDef: ChartDefinition = {
     {key: "pointSizeScale", default: "linear"},
     {key: "projection", default: d3Geo.geoMercator()},
     {key: "projectionPadding", default: parseSides(20)},
-    {key: "shape", default: constant("Circle")},
+    {key: "shape", default: constant("Circle"), coerce: "const"},
     {key: "topojson", default: false},
     {key: "topojsonFill", default: constant("#f5f5f3")},
     {

--- a/packages/core/src/charts/LinePlot/index.ts
+++ b/packages/core/src/charts/LinePlot/index.ts
@@ -17,7 +17,7 @@ export const linePlotDef: ChartDefinition = {
 
   fields: [
     {key: "discrete", default: "x"},
-    {key: "shape", default: constant("Line")},
+    {key: "shape", default: constant("Line"), coerce: "const"},
   ],
 };
 

--- a/packages/core/src/charts/Matrix/index.ts
+++ b/packages/core/src/charts/Matrix/index.ts
@@ -92,6 +92,7 @@ export const matrixDef: ChartDefinition = {
     {key: "columnConfig", merge: true, default: {orient: "top", ...defaultAxisConfig}},
     {
       key: "label",
+      coerce: "const",
       factory: (viz: VizInstance) => (d: DataPoint, i: number) =>
         `${getProp.bind(viz)("row", d, i)} / ${getProp.bind(viz)("column", d, i)}`,
     },

--- a/packages/core/src/charts/Network/index.ts
+++ b/packages/core/src/charts/Network/index.ts
@@ -337,7 +337,7 @@ export const networkDef: ChartDefinition = {
     {key: "sizeMax"},
     {key: "sizeMin", default: 5},
     {key: "sizeScale", default: "sqrt"},
-    {key: "shape", default: constant("Circle")},
+    {key: "shape", default: constant("Circle"), coerce: "const"},
     {
       key: "shapeConfig",
       merge: true,

--- a/packages/core/src/charts/Pack/index.ts
+++ b/packages/core/src/charts/Pack/index.ts
@@ -95,6 +95,7 @@ export const packDef: ChartDefinition = {
     },
     {
       key: "legend",
+      coerce: "const",
       factory: (viz: VizInstance) => {
         const base = viz.schema.legend as (config: D3plusConfig, arr: DataPoint[]) => unknown;
         return (config: D3plusConfig, arr: DataPoint[]) => {

--- a/packages/core/src/charts/Pie/index.ts
+++ b/packages/core/src/charts/Pie/index.ts
@@ -110,6 +110,7 @@ export const pieDef: DataDrivenChartDefinition = {
     },
     {
       key: "legend",
+      coerce: "const",
       factory: (viz: VizInstance) => {
         const base = viz.schema.legend as (config: D3plusConfig, arr: DataPoint[]) => unknown;
         return (config: D3plusConfig, arr: DataPoint[]) => {

--- a/packages/core/src/charts/Radar/index.ts
+++ b/packages/core/src/charts/Radar/index.ts
@@ -43,7 +43,7 @@ export const radarDef: ChartDefinition = {
       coerce: v => (typeof v === "function" ? v : accessor(v as string)),
     },
     {key: "outerPadding", default: 100},
-    {key: "shape", default: constant("Path")},
+    {key: "shape", default: constant("Path"), coerce: "const"},
     {
       key: "value",
       default: accessor("value"),

--- a/packages/core/src/charts/RadialMatrix/index.ts
+++ b/packages/core/src/charts/RadialMatrix/index.ts
@@ -125,6 +125,7 @@ export const radialMatrixDef: ChartDefinition = {
     },
     {
       key: "label",
+      coerce: "const",
       factory: (viz: VizInstance) => (d: DataPoint, i: number) =>
         `${getProp.bind(viz)("row", d, i)} / ${getProp.bind(viz)("column", d, i)}`,
     },

--- a/packages/core/src/charts/Rings/index.ts
+++ b/packages/core/src/charts/Rings/index.ts
@@ -190,7 +190,7 @@ export const ringsDef: ChartDefinition = {
     {key: "sizeMax"},
     {key: "sizeMin", default: 5},
     {key: "sizeScale", default: "sqrt"},
-    {key: "shape", default: constant("Circle")},
+    {key: "shape", default: constant("Circle"), coerce: "const"},
     {
       key: "shapeConfig",
       merge: true,

--- a/packages/core/src/charts/Sankey/index.ts
+++ b/packages/core/src/charts/Sankey/index.ts
@@ -164,7 +164,7 @@ export const sankeyDef: ChartDefinition = {
     {key: "nodeSort"},
     {key: "nodeWidth", default: 30},
     {key: "value", default: constant(1)},
-    {key: "shape", default: constant("Rect")},
+    {key: "shape", default: constant("Rect"), coerce: "const"},
     {
       key: "shapeConfig",
       merge: true,

--- a/packages/core/src/charts/Tree/index.ts
+++ b/packages/core/src/charts/Tree/index.ts
@@ -42,7 +42,7 @@ export const treeDef: ChartDefinition = {
       default: (a: {parent: unknown}, b: {parent: unknown}) =>
         a.parent === b.parent ? 1 : 2,
     },
-    {key: "shape", default: constant("Circle")},
+    {key: "shape", default: constant("Circle"), coerce: "const"},
     {
       key: "shapeConfig",
       merge: true,

--- a/packages/core/src/charts/Treemap/index.ts
+++ b/packages/core/src/charts/Treemap/index.ts
@@ -165,6 +165,7 @@ export const treemapDef: ChartDefinition = {
     },
     {
       key: "legend",
+      coerce: "const",
       factory: (viz: VizInstance) => {
         const base = viz.schema.legend as (config: D3plusConfig, arr: DataPoint[]) => unknown;
         return (config: D3plusConfig, arr: DataPoint[]) => {

--- a/packages/core/test/charts/legend-boolean-coercion-test.js
+++ b/packages/core/test/charts/legend-boolean-coercion-test.js
@@ -1,0 +1,52 @@
+import assert from "assert";
+import it from "../jsdom.js";
+import {BarChart, Donut, Matrix, Pack, Pie, Treemap} from "../../es/index.js";
+
+// Charts that declare `legend`/`shape`/`label` in their def `fields` get a
+// generated fluent accessor that shadows the hand-written VizBaseConfig setter.
+// The generated accessor honours the field's `coerce`, so without an explicit
+// `"const"` a `.legend(false)`/`.shape("Circle")` call stored the raw primitive
+// instead of wrapping it in `constant(...)`. Readers that treat the value as a
+// function then blew up — `featuresLegend` does `viz.schema.legend.bind(viz)(…)`,
+// and `false.bind` is not a function.
+it("legend accessor keeps schema.legend callable for boolean args", () => {
+  for (const Chart of [BarChart, Pie, Donut, Treemap, Pack]) {
+    const viz = new Chart();
+
+    viz.legend(false);
+    assert.strictEqual(
+      typeof viz.schema.legend,
+      "function",
+      `${Chart.name}: .legend(false) must store a function`,
+    );
+    // Exercise the exact featuresLegend call shape.
+    assert.doesNotThrow(
+      () => viz.schema.legend.bind(viz)({}, []),
+      `${Chart.name}: schema.legend.bind() must not throw`,
+    );
+    assert.strictEqual(viz.schema.legend.bind(viz)({}, []), false, `${Chart.name}: legend(false) → false`);
+
+    viz.legend(true);
+    assert.strictEqual(typeof viz.schema.legend, "function", `${Chart.name}: .legend(true) stays a function`);
+    assert.strictEqual(viz.schema.legend.bind(viz)({}, []), true, `${Chart.name}: legend(true) → true`);
+
+    // A function argument still passes straight through.
+    const fn = () => false;
+    viz.legend(fn);
+    assert.strictEqual(viz.schema.legend, fn, `${Chart.name}: function arg passes through`);
+  }
+});
+
+it("shape accessor coerces string args to constant functions", () => {
+  const viz = new BarChart();
+  viz.shape("Circle");
+  assert.strictEqual(typeof viz.schema.shape, "function", "shape string → constant fn");
+  assert.strictEqual(viz.schema.shape({}, 0), "Circle", "shape fn returns the constant");
+});
+
+it("label accessor coerces string args to constant functions", () => {
+  const viz = new Matrix();
+  viz.label("Region");
+  assert.strictEqual(typeof viz.schema.label, "function", "label string → constant fn");
+  assert.strictEqual(viz.schema.label({}, 0), "Region", "label fn returns the constant");
+});


### PR DESCRIPTION
## Problem

`featuresLegend` crashes when a chart's legend is toggled with a boolean:

```ts
// featuresLegend.ts
position === false ? false : viz.schema.legend.bind(viz)(config, legendData);
```

Calling `.legend(false)` on a BarChart/Pie/Treemap/Pack/Donut leaves
`schema.legend === false`, so `false.bind(...)` throws `is not a function`.

## Root cause

Charts that declare `legend`, `shape`, or `label` in their def `fields` get a
**generated fluent accessor** (installed on the chart prototype by
`installFluent`) that *shadows* the hand-written setter in
`VizBaseConfig`/`VizBase`. The hand-written setters keep the value callable:

```ts
this.schema.legend = typeof _ === "function" ? _ : constant(_); // always a fn
```

…but the field declarations used the default `identity` coerce, so the
shadowing accessor stored the **raw primitive**. The same latent bug affected
`.shape("Circle")` (breaks `viz.schema.shape(d, i)`) and `.label("x")`.

## Fix

Add `coerce: "const"` to each colliding field so the generated accessor matches
the hand-written setter's `constant()`-wrapping and the values stay callable:

- **legend** — BarChart, Pie, Treemap, Pack (Donut inherits Pie's)
- **shape** — AreaPlot, BarChart, BoxWhisker, BumpChart, Geomap, LinePlot, Network, Radar, Rings, Sankey, Tree (Pack already had an equivalent inline coerce)
- **label** — Matrix, RadialMatrix

Chosen over a central `installFluent` change because that helper is shared by
all shapes/components and the E4/Plot design relies on its shadowing behavior —
the bug is precisely a coercion mismatch, so fixing it at the field keeps the
blast radius to zero.

### Other `.bind`-on-`schema` sites (checked, not affected)

`legendPosition`, `colorScalePosition`, `legendFilterInvert`, `groupBy` aren't
field keys (their const-wrapping hand-written setters always yield functions);
`curve` already uses `coerce: "const"`; `bucketFormat` is generated-only with a
function-by-contract default (no shadowing).

## Testing

- New `test/charts/legend-boolean-coercion-test.js` exercises the exact
  `schema.legend.bind(viz)(…)` pattern across BarChart/Pie/Donut/Treemap/Pack
  plus shape/label. Confirmed it fails when the coerce is reverted and passes
  with the fix.
- `tsc --noEmit` clean, eslint clean.
- Full core suite: **205 passing** (202 prior + 3 new), including every
  per-chart visual snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)