### PR TITLE
feat: value- and field-based stack ordering (#527)

### DIFF
--- a/packages/core/src/charts/Plot/index.ts
+++ b/packages/core/src/charts/Plot/index.ts
@@ -1,6 +1,5 @@
 /* eslint no-cond-assign: 0*/
 
-import * as d3Shape from "d3-shape";
 // @ts-ignore
 import pkg from "open-color/open-color.js";
 const {theme: openColor} = pkg;
@@ -49,7 +48,15 @@ const plotSchema = [
 import {plotDef} from "./pipeline.js";
 import {drawPlot} from "./draw.js";
 import {plotShapeDefaults} from "./shapeDefaults.js";
-import {stackOffsetDiverging, stackOrderAscending, stackOrderDescending} from "./stackHelpers.js";
+import {
+  resolveStackOffset,
+  resolveStackOrder,
+  stackOffsetDiverging,
+  stackOrderTotalDescending,
+  type StackOffsetFn,
+  type StackOrderFn,
+  type StackOrderInput,
+} from "./stackHelpers.js";
 import {plotPaint, type PlotPaintContext} from "../features/plotPaint.js";
 import Viz from "../viz/Viz.js";
 
@@ -132,7 +139,7 @@ export default class Plot extends Viz {
     this.schema.sizeMin = 5;
     this.schema.sizeScale = "sqrt";
     this._stackOffset = stackOffsetDiverging;
-    this._stackOrder = stackOrderDescending;
+    this._stackOrder = stackOrderTotalDescending;
     this.schema.timelineConfig = assign(this.schema.timelineConfig, {
       brushMin: () =>
         this._xTime || this._yTime || this._x2Time || this._y2Time ? 2 : 1,
@@ -476,41 +483,36 @@ Additionally, each config object can also contain an optional "layer" key, which
   }
 
   /**
-      Sets the stack offset. If *value* is not specified, returns the current stack offset function.
+      Sets the vertical offset applied to stacked series. Accepts a named
+      offset — `"diverging"` (default), `"none"`, `"expand"`, `"silhouette"`,
+      or `"wiggle"` — or a custom offset function. Unknown names warn and fall
+      back to `"diverging"`. If *value* is not specified, returns the current
+      stack offset function.
 */
-  stackOffset(
-    _?: string | ((series: number[][], order: number[]) => void),
-  ): this | ((series: number[][], order: number[]) => void) {
+  stackOffset(_?: string | StackOffsetFn): this | StackOffsetFn {
     return arguments.length
-      ? ((this._stackOffset =
-          typeof _ === "function"
-            ? _
-            : (d3Shape as Record<string, unknown>)[
-                `stackOffset${_!.charAt(0).toUpperCase() + _!.slice(1)}`
-              ]),
-        this)
-      : this._stackOffset;
+      ? ((this._stackOffset = resolveStackOffset(_!)), this)
+      : (this._stackOffset as StackOffsetFn);
   }
 
   /**
-      Sets the stack order. If *value* is not specified, returns the current stack order function.
+      Sets the order of stacked series, from the bottom of the stack upward.
+      Accepts:
+      - a named order: `"descending"` (default) / `"ascending"` by summed
+        value, `"key"` / `"keyReverse"` alphabetically by series key,
+        `"none"` / `"data"` for input order, or d3's `"insideOut"`,
+        `"appearance"`, `"reverse"`;
+      - an Array of series keys for an explicit order;
+      - a value accessor, or a `{value, order}` config, to rank series by an
+        aggregate of any data field.
+
+      Unknown named strings warn and fall back to `"descending"`. If *value*
+      is not specified, returns the current stack order.
 */
-  stackOrder(
-    _?: string | ((series: number[][]) => number[]),
-  ): this | ((series: number[][]) => number[]) {
-    if (arguments.length) {
-      if (typeof _ === "string")
-        this._stackOrder =
-          _ === "ascending"
-            ? stackOrderAscending
-            : _ === "descending"
-              ? stackOrderDescending
-              : (d3Shape as Record<string, unknown>)[
-                  `stackOrder${_.charAt(0).toUpperCase() + _.slice(1)}`
-                ];
-      else this._stackOrder = _;
-      return this;
-    } else return this._stackOrder;
+  stackOrder(_?: StackOrderInput): this | StackOrderFn | string[] {
+    return arguments.length
+      ? ((this._stackOrder = resolveStackOrder(_!)), this)
+      : (this._stackOrder as StackOrderFn | string[]);
   }
 
   /**

--- a/packages/core/src/charts/Plot/pipelineDomains.ts
+++ b/packages/core/src/charts/Plot/pipelineDomains.ts
@@ -134,10 +134,11 @@ function computeStackedDomains(viz: VizInstance, ctx: StackedCtx): Partial<VizCo
 
   const order = viz._stackOrder;
 
+  // An explicit key array orders `stackKeys` directly (then d3-stack keeps
+  // that order via `stackOrderNone`); every other order is a comparator that
+  // reranks the series d3-stack builds, so `stackKeys` is left in input order.
   if (Array.isArray(order))
     stackKeys.sort((a, b) => order.indexOf(a) - order.indexOf(b));
-  else if ((order as unknown) === d3Shape.stackOrderNone)
-    stackKeys.sort((a, b) => `${a}`.localeCompare(`${b}`));
 
   // d3-stack's generics don't model d3plus's dynamically-keyed rows; the
   // order/offset/value accessors are cast (`as never`) at the boundary, and

--- a/packages/core/src/charts/Plot/stackHelpers.ts
+++ b/packages/core/src/charts/Plot/stackHelpers.ts
@@ -1,10 +1,59 @@
 /**
     d3-stack ordering + offset helpers used by Plot's `stackOrder` /
     `stackOffset` accessors and their constructor defaults.
+
+    `resolveStackOrder` / `resolveStackOffset` normalize the many shapes a
+    user can pass (named string, data key, value accessor, `{value, order}`
+    config, explicit key array, or raw comparator) into the single value the
+    pipeline applies: a tagged comparator or an array of series keys.
 */
 import * as d3Shape from "d3-shape";
 
+import type {DataPoint} from "@d3plus/data";
+
+import accessor from "../../utils/accessor.js";
+
 type Series = d3Shape.Series<Record<string, unknown>, string>;
+
+/** A resolved d3-stack order comparator. Tagged with `__d3plusStackOrder` so
+    the `stackOrder` setter can tell an already-resolved order (e.g. the
+    constructor default, or a value round-tripped by `config()` reset) from a
+    raw user value accessor that still needs wrapping. */
+export type StackOrderFn = ((series: Series[]) => number[]) & {
+  __d3plusStackOrder?: true;
+};
+
+/** Per-datum value accessor accepted for field-based ordering. */
+type ValueAccessor = (d: DataPoint, i?: number) => unknown;
+
+/** `{value, order}` config for ordering series by an arbitrary data field. */
+export interface StackOrderFieldConfig {
+  /** Data key or accessor whose aggregated value ranks each series. */
+  value: string | ValueAccessor;
+  /** Sort direction of the aggregate (default `"descending"`). */
+  order?: "ascending" | "descending";
+}
+
+/** Every shape `Plot.stackOrder` accepts. */
+export type StackOrderInput =
+  | string
+  | string[]
+  | StackOrderFieldConfig
+  | ValueAccessor
+  | StackOrderFn;
+
+/** A single formatted Plot row, as carried on each stacked point's `.data`. */
+type Row = {id?: unknown; data?: DataPoint; [key: string]: unknown};
+
+/** Marks a comparator as an already-resolved d3plus stack order. */
+function tagOrder(fn: (series: Series[]) => number[]): StackOrderFn {
+  (fn as StackOrderFn).__d3plusStackOrder = true;
+  return fn as StackOrderFn;
+}
+
+// @types/d3-shape types the order accessors' param as a single `Series`,
+// though d3 passes the full stack array; this cast satisfies the signature.
+const asStack = (series: Series[]) => series as unknown as Series;
 
 /**
     Sums a single stack series, ignoring non-numeric segments.
@@ -19,23 +68,116 @@ export function stackSum(series: Series): number {
 }
 
 /**
-    Stack order: ascending by series key, tie-broken by summed value.
+    Stack order: series with the smallest summed value on the bottom of the
+    stack (matches d3's `stackOrderAscending`).
 */
-export function stackOrderAscending(series: Series[]): number[] {
-  const sums = series.map(stackSum);
-  const keys = series.map((d: Series) => d.key.split("_")[0]);
-  // @types/d3-shape types the order accessors' param as a single `Series`,
-  // though d3 passes the full stack array; cast to satisfy the signature.
-  return d3Shape
-    .stackOrderNone(series as unknown as Series)
-    .sort((a: number, b: number) => keys[b].localeCompare(keys[a]) || sums[a] - sums[b]);
-}
+export const stackOrderTotalAscending = tagOrder((series: Series[]) =>
+  d3Shape.stackOrderAscending(asStack(series)),
+);
 
 /**
-    Stack order: the reverse of {@link stackOrderAscending}.
+    Stack order: series with the largest summed value on the bottom of the
+    stack (matches d3's `stackOrderDescending`). Plot's default.
 */
-export function stackOrderDescending(series: Series[]): number[] {
-  return stackOrderAscending(series).reverse();
+export const stackOrderTotalDescending = tagOrder((series: Series[]) =>
+  d3Shape.stackOrderDescending(asStack(series)),
+);
+
+/**
+    Stack order: ascending by series key (A→Z from the bottom), tie-broken by
+    ascending summed value.
+*/
+export const stackOrderKey = tagOrder((series: Series[]) => {
+  const sums = series.map(stackSum);
+  const keys = series.map((d: Series) => d.key.split("_")[0]);
+  return d3Shape
+    .stackOrderNone(asStack(series))
+    .sort((a: number, b: number) => keys[a].localeCompare(keys[b]) || sums[a] - sums[b]);
+});
+
+/**
+    Stack order: the reverse of {@link stackOrderKey} (Z→A from the bottom).
+*/
+export const stackOrderKeyReverse = tagOrder((series: Series[]) =>
+  stackOrderKey(series).reverse(),
+);
+
+/**
+    Builds a stack order that ranks each series by an aggregate (sum) of a
+    data field, letting users order stacks by any value in their data rather
+    than only the plotted one. `value` receives each series' original datum.
+*/
+export function stackOrderField(
+  value: ValueAccessor,
+  order: "ascending" | "descending" = "descending",
+): StackOrderFn {
+  return tagOrder((series: Series[]) => {
+    const totals = series.map((s: Series) => {
+      let total = 0;
+      for (let i = 0; i < s.length; i++) {
+        // Each stacked point carries `.data` = the discrete group's rows;
+        // pick the row for this series and read the field off its datum.
+        const group = ((s[i] as unknown as {data?: Row[]}).data || []) as Row[];
+        const row = group.find((g: Row) => g.id === s.key);
+        if (row && row.data) {
+          const v = +(value(row.data) as number);
+          if (!isNaN(v)) total += v;
+        }
+      }
+      return total;
+    });
+    return d3Shape
+      .stackOrderNone(asStack(series))
+      .sort((a: number, b: number) =>
+        order === "ascending" ? totals[a] - totals[b] : totals[b] - totals[a],
+      );
+  });
+}
+
+/** Named stack orders accepted by `Plot.stackOrder`. */
+const NAMED_ORDERS: Record<string, StackOrderFn> = {
+  ascending: stackOrderTotalAscending,
+  descending: stackOrderTotalDescending,
+  key: stackOrderKey,
+  keyReverse: stackOrderKeyReverse,
+  none: tagOrder((series: Series[]) => d3Shape.stackOrderNone(asStack(series))),
+  data: tagOrder((series: Series[]) => d3Shape.stackOrderNone(asStack(series))),
+  insideOut: tagOrder((series: Series[]) => d3Shape.stackOrderInsideOut(asStack(series))),
+  appearance: tagOrder((series: Series[]) => d3Shape.stackOrderAppearance(asStack(series))),
+  reverse: tagOrder((series: Series[]) => d3Shape.stackOrderReverse(asStack(series))),
+};
+
+/** The named orders accepted by `Plot.stackOrder`, for docs/validation. */
+export const stackOrderNames = Object.keys(NAMED_ORDERS);
+
+/**
+    Normalizes any `stackOrder` input into a value Plot's pipeline can apply:
+    a tagged comparator, or an explicit array of series keys. Warns and falls
+    back to the default on an unrecognized name.
+*/
+export function resolveStackOrder(input: StackOrderInput): StackOrderFn | string[] {
+  if (typeof input === "function") {
+    // Already-resolved order (constructor default / config() reset) passes
+    // through; a bare user function is treated as a value accessor.
+    return (input as StackOrderFn).__d3plusStackOrder
+      ? (input as StackOrderFn)
+      : stackOrderField(input as ValueAccessor);
+  }
+  if (Array.isArray(input)) return input;
+  if (input && typeof input === "object") {
+    const {value, order} = input as StackOrderFieldConfig;
+    return stackOrderField(typeof value === "function" ? value : accessor(value), order);
+  }
+  if (typeof input === "string") {
+    if (input in NAMED_ORDERS) return NAMED_ORDERS[input];
+    console.warn(
+      `[d3plus] Unknown stackOrder "${input}". Expected one of: ${stackOrderNames.join(
+        ", ",
+      )}; an array of series keys; a value accessor; or a {value, order} config. Falling back to "descending".`,
+    );
+    return stackOrderTotalDescending;
+  }
+  return stackOrderTotalDescending;
 }
 
 /**
@@ -58,4 +200,34 @@ export function stackOffsetDiverging(series: Series[], order: number[]): void {
       }
     }
   }
+}
+
+/** A stack offset function, as applied by d3-stack. */
+export type StackOffsetFn = (series: number[][][], order: number[]) => void;
+
+/** Named stack offsets accepted by `Plot.stackOffset`. */
+const NAMED_OFFSETS: Record<string, StackOffsetFn> = {
+  diverging: stackOffsetDiverging as unknown as StackOffsetFn,
+  none: d3Shape.stackOffsetNone as unknown as StackOffsetFn,
+  expand: d3Shape.stackOffsetExpand as unknown as StackOffsetFn,
+  silhouette: d3Shape.stackOffsetSilhouette as unknown as StackOffsetFn,
+  wiggle: d3Shape.stackOffsetWiggle as unknown as StackOffsetFn,
+};
+
+/** The named offsets accepted by `Plot.stackOffset`, for docs/validation. */
+export const stackOffsetNames = Object.keys(NAMED_OFFSETS);
+
+/**
+    Normalizes a `stackOffset` input into an offset function. Warns and falls
+    back to the diverging default on an unrecognized name.
+*/
+export function resolveStackOffset(input: string | StackOffsetFn): StackOffsetFn {
+  if (typeof input === "function") return input;
+  if (typeof input === "string" && input in NAMED_OFFSETS) return NAMED_OFFSETS[input];
+  console.warn(
+    `[d3plus] Unknown stackOffset "${input}". Expected one of: ${stackOffsetNames.join(
+      ", ",
+    )}; or an offset function. Falling back to "diverging".`,
+  );
+  return stackOffsetDiverging as unknown as StackOffsetFn;
 }

--- a/packages/core/src/utils/D3plusConfig.ts
+++ b/packages/core/src/utils/D3plusConfig.ts
@@ -395,8 +395,26 @@ export interface D3plusConfig {
   size?: string;
   /** Whether to stack series. */
   stacked?: boolean;
-  /** Custom order for stacked series. */
-  stackOrder?: string[];
+  /**
+      Vertical offset applied to stacked series. One of `"diverging"`
+      (default — positive and negative values split around zero), `"none"`,
+      `"expand"` (normalize each stack to 100%), `"silhouette"` (streamgraph),
+      or `"wiggle"` (minimize slope changes); or a custom offset function.
+  */
+  stackOffset?: string | ((series: number[][][], order: number[]) => void);
+  /**
+      Order of stacked series, from the bottom of the stack upward. Accepts a
+      named order (`"descending"` [default] / `"ascending"` by summed value,
+      `"key"` / `"keyReverse"` alphabetically, `"none"` / `"data"` for input
+      order, or d3's `"insideOut"` / `"appearance"` / `"reverse"`), an Array of
+      series keys for an explicit order, a value accessor, or a `{value, order}`
+      config to rank series by an aggregate of any data field.
+  */
+  stackOrder?:
+    | string
+    | string[]
+    | {value: string | ((d: DataPoint) => unknown); order?: "ascending" | "descending"}
+    | ((d: DataPoint) => unknown);
   /** Subtitle text, or an accessor returning it. */
   subtitle?: string | ((data: DataPoint[]) => string);
   /** Whether the subtitle uses the visualization's internal padding when positioning, or an accessor receiving the viz. */

--- a/packages/core/test/charts/stackHelpers-test.js
+++ b/packages/core/test/charts/stackHelpers-test.js
@@ -1,8 +1,14 @@
+/* global console */
 import assert from "assert";
 import {
+  resolveStackOffset,
+  resolveStackOrder,
   stackOffsetDiverging,
-  stackOrderAscending,
-  stackOrderDescending,
+  stackOrderField,
+  stackOrderKey,
+  stackOrderKeyReverse,
+  stackOrderTotalAscending,
+  stackOrderTotalDescending,
   stackSum,
 } from "../../es/src/charts/Plot/stackHelpers.js";
 
@@ -14,33 +20,107 @@ it("charts/stackHelpers stackSum totals the upper bounds, ignoring non-numbers",
   assert.strictEqual(stackSum([[0, 2], [2, "x"]]), 2, "non-numeric segments are skipped");
 });
 
-it("charts/stackHelpers stackOrderAscending orders series by key, descending alphabetically", () => {
+it("charts/stackHelpers stackOrderTotal* orders by summed value", () => {
   const series = [
-    mkSeries("a", [[0, 1]]),
-    mkSeries("b", [[0, 5]]),
-    mkSeries("c", [[0, 3]]),
+    mkSeries("a", [[0, 1]]),  // sum 1
+    mkSeries("b", [[0, 5]]),  // sum 5
+    mkSeries("c", [[0, 3]]),  // sum 3
   ];
-  // Distinct keys → no sum tie-break; result is the indices in descending key order.
-  assert.deepStrictEqual(stackOrderAscending(series), [2, 1, 0]);
+  // Ascending: smallest total (a) first → on the bottom of the stack.
+  assert.deepStrictEqual(stackOrderTotalAscending(series), [0, 2, 1], "ascending by sum");
+  // Descending: largest total (b) first.
+  assert.deepStrictEqual(stackOrderTotalDescending(series), [1, 2, 0], "descending by sum");
 });
 
-it("charts/stackHelpers stackOrderAscending breaks key ties by ascending sum", () => {
-  // Both keys share the prefix "g", so the localeCompare is 0 and the
-  // smaller-sum series sorts first.
+it("charts/stackHelpers stackOrderKey* orders alphabetically by series key", () => {
+  const series = [
+    mkSeries("b", [[0, 5]]),
+    mkSeries("a", [[0, 1]]),
+    mkSeries("c", [[0, 3]]),
+  ];
+  // key: A→Z from the bottom → a (index 1), b (0), c (2).
+  assert.deepStrictEqual(stackOrderKey(series), [1, 0, 2], "A→Z");
+  assert.deepStrictEqual(stackOrderKeyReverse(series), [2, 0, 1], "Z→A");
+});
+
+it("charts/stackHelpers stackOrderKey breaks key ties by ascending sum", () => {
+  // Both keys share the prefix "g" (split on \"_\"), so the sum tie-break wins.
   const series = [
     mkSeries("g_1", [[0, 10]]),
     mkSeries("g_2", [[0, 3]]),
   ];
-  assert.deepStrictEqual(stackOrderAscending(series), [1, 0]);
+  assert.deepStrictEqual(stackOrderKey(series), [1, 0], "smaller sum first on a key tie");
 });
 
-it("charts/stackHelpers stackOrderDescending is the reverse of ascending", () => {
+it("charts/stackHelpers stackOrderField ranks series by an aggregate of a data field", () => {
+  // Each stacked point carries `.data` = the discrete group's rows; each row
+  // has an `id` (the series key) and its original `data`.
+  const g0 = [{id: "a", data: {v: 10}}, {id: "b", data: {v: 1}}];
+  const g1 = [{id: "a", data: {v: 20}}, {id: "b", data: {v: 2}}];
+  const withData = (point, group) => Object.assign(point.slice(), {data: group});
   const series = [
-    mkSeries("a", [[0, 1]]),
-    mkSeries("b", [[0, 5]]),
-    mkSeries("c", [[0, 3]]),
+    mkSeries("a", [withData([0, 10], g0), withData([0, 20], g1)]), // field total 30
+    mkSeries("b", [withData([0, 1], g0), withData([0, 2], g1)]),   // field total 3
   ];
-  assert.deepStrictEqual(stackOrderDescending(series), [0, 1, 2]);
+  const value = d => d.v;
+  // Default descending: largest field total (a) first.
+  assert.deepStrictEqual(stackOrderField(value)(series), [0, 1], "descending field total");
+  assert.deepStrictEqual(
+    stackOrderField(value, "ascending")(series),
+    [1, 0],
+    "ascending field total",
+  );
+});
+
+it("charts/stackHelpers resolveStackOrder maps every input shape", () => {
+  // Named orders resolve to the corresponding tagged comparator.
+  assert.strictEqual(resolveStackOrder("descending"), stackOrderTotalDescending);
+  assert.strictEqual(resolveStackOrder("ascending"), stackOrderTotalAscending);
+  assert.strictEqual(resolveStackOrder("key"), stackOrderKey);
+  assert.strictEqual(resolveStackOrder("keyReverse"), stackOrderKeyReverse);
+
+  // An explicit key array is returned untouched.
+  const keys = ["b", "a"];
+  assert.strictEqual(resolveStackOrder(keys), keys);
+
+  // Accessor + {value, order} config both resolve to tagged field comparators.
+  const fromAccessor = resolveStackOrder(d => d.v);
+  assert.strictEqual(typeof fromAccessor, "function");
+  assert.strictEqual(fromAccessor.__d3plusStackOrder, true);
+  const fromConfig = resolveStackOrder({value: "v", order: "ascending"});
+  assert.strictEqual(fromConfig.__d3plusStackOrder, true);
+
+  // An already-resolved comparator passes through (config() reset round-trip).
+  assert.strictEqual(resolveStackOrder(stackOrderTotalAscending), stackOrderTotalAscending);
+});
+
+it("charts/stackHelpers resolveStackOrder warns and falls back on an unknown name", () => {
+  const original = console.warn;
+  let warned = "";
+  console.warn = msg => { warned = msg; };
+  try {
+    assert.strictEqual(resolveStackOrder("acsending"), stackOrderTotalDescending);
+  } finally {
+    console.warn = original;
+  }
+  assert.ok(/Unknown stackOrder "acsending"/.test(warned), "warns with the bad value");
+});
+
+it("charts/stackHelpers resolveStackOffset maps names, passes functions, warns on unknown", () => {
+  assert.strictEqual(resolveStackOffset("diverging"), stackOffsetDiverging);
+  const custom = () => {};
+  assert.strictEqual(resolveStackOffset(custom), custom, "functions pass through");
+  assert.strictEqual(typeof resolveStackOffset("expand"), "function", "d3 offset by name");
+
+  const original = console.warn;
+  let warned = "";
+  console.warn = msg => { warned = msg; };
+  try {
+    assert.strictEqual(resolveStackOffset("expnd"), stackOffsetDiverging);
+  } finally {
+    console.warn = original;
+  }
+  assert.ok(/Unknown stackOffset "expnd"/.test(warned), "warns with the bad value");
 });
 
 it("charts/stackHelpers stackOffsetDiverging stacks positives up and negatives down from zero", () => {

--- a/packages/core/test/charts/stackOrdering-test.js
+++ b/packages/core/test/charts/stackOrdering-test.js
@@ -1,0 +1,90 @@
+import assert from "assert";
+import it from "../jsdom.js";
+import {computePlotAxisValues, computePlotInitialDomains, formatPlotData} from "../../es/src/charts/Plot/pipeline.js";
+import accessor from "../../es/src/utils/accessor.js";
+import {resolveStackOrder, stackOffsetDiverging} from "../../es/src/charts/Plot/stackHelpers.js";
+
+// Drives Plot's real stacking pipeline (format → axis values → initial
+// domains) against a hand-rolled viz stub, so the ordering path is exercised
+// exactly as it runs in a chart — no Plot instance, no DOM.
+const makeStackedViz = (data, stackOrder) => ({
+  _filteredData: data,
+  _data: [],
+  _ids: d => [d.id],
+  _drawDepth: 0,
+  _groupBy: [accessor("id")],
+  _axisPersist: false,
+  _confidence: false,
+  _size: false,
+  _x: accessor("x"),
+  _y: accessor("y"),
+  _x2: accessor("x2"),
+  _y2: accessor("y2"),
+  _xConfig: {}, _x2Config: {}, _yConfig: {}, _y2Config: {},
+  _baseline: 0,
+  _margin: {top: 0, right: 0, bottom: 0, left: 0},
+  _stackOrder: resolveStackOrder(stackOrder),
+  _stackOffset: stackOffsetDiverging,
+  schema: {
+    discrete: "x",
+    stacked: true,
+    shape: () => "Area",
+    time: false,
+    groupBy: [accessor("id")],
+    xSort: false, x2Sort: false, ySort: false, y2Sort: false,
+    xDomain: undefined, x2Domain: undefined, yDomain: undefined, y2Domain: undefined,
+    sizeScale: "sqrt", sizeMax: 10, sizeMin: 5,
+    height: 300, width: 400,
+  },
+});
+
+// Runs the three pipeline stages and returns the initial-domains ctx patch.
+const runStack = (data, stackOrder) => {
+  const viz = makeStackedViz(data, stackOrder);
+  const fmt = formatPlotData({viz});
+  const av = computePlotAxisValues({viz, ...fmt});
+  return computePlotInitialDomains({viz, ...fmt, ...av});
+};
+
+// "low"/"high" series across two discrete positions.
+const rows = x => [
+  {id: "low",  x, y: 1},
+  {id: "high", x, y: 9},
+];
+const intData = [...rows(2000), ...rows(2001)];
+const strData = [...rows("2000"), ...rows("2001")];
+
+it("charts/stackOrdering honors an explicit key order with an integer x axis (#527)", () => {
+  // The original bug: custom stack ordering was ignored when x was numeric.
+  const partial = runStack(intData, ["high", "low"]);
+  assert.deepStrictEqual(partial.plotStackKeys, ["high", "low"], "explicit order applied");
+});
+
+it("charts/stackOrdering gives the same order for integer and string x axes", () => {
+  const asInt = runStack(intData, ["high", "low"]);
+  const asStr = runStack(strData, ["high", "low"]);
+  assert.deepStrictEqual(
+    asInt.plotStackKeys,
+    asStr.plotStackKeys,
+    "x data type does not affect stack order",
+  );
+});
+
+it("charts/stackOrdering builds a valid, finite stack from an integer x axis", () => {
+  const partial = runStack(intData, ["high", "low"]);
+  // All-positive series stack from a zero baseline; each x totals 1 + 9 = 10.
+  assert.deepStrictEqual(partial.plotInitialDomains.y, [0, 10], "y domain spans the stack");
+  assert.ok(partial.plotStackData.length > 0, "stack data produced");
+  assert.ok(
+    partial.plotStackData.every(s => s.every(p => Number.isFinite(p[0]) && Number.isFinite(p[1]))),
+    "no NaN coordinates",
+  );
+});
+
+it("charts/stackOrdering default 'descending' puts the largest-total series on the bottom", () => {
+  // "high" totals 18, "low" totals 3 → high sits on the zero baseline.
+  const partial = runStack(intData, "descending");
+  const high = partial.plotStackData.find(s => s.key === "high");
+  assert.ok(high, "high series present");
+  assert.ok(high.every(p => p[0] === 0), "largest-total series anchored at the baseline");
+});

--- a/packages/docs/packages/core/charts/BarChart.stories.jsx
+++ b/packages/docs/packages/core/charts/BarChart.stories.jsx
@@ -465,3 +465,46 @@ OrdinalColor.parameters = {
   controls: {include: ["colorOrdinal"]},
   docs: {description: {story: "Set `colorOrdinal: true` to color an *ordered* discrete field with a single-hue light→dark ramp instead of unrelated categorical hues, so the color itself carries the order. The ramp follows the data order (numeric values sort ascending); here the tiers run XS→XL from light to dark."}}
 };
+
+// Three series with clearly different totals, plotted over a numeric year
+// axis (integer x) so the ordering is easy to read.
+const revenueByYear = [
+  {segment: "Enterprise", year: 2021, revenue: 40},
+  {segment: "Enterprise", year: 2022, revenue: 46},
+  {segment: "Enterprise", year: 2023, revenue: 52},
+  {segment: "Retail",     year: 2021, revenue: 25},
+  {segment: "Retail",     year: 2022, revenue: 28},
+  {segment: "Retail",     year: 2023, revenue: 27},
+  {segment: "Online",     year: 2021, revenue:  8},
+  {segment: "Online",     year: 2022, revenue: 14},
+  {segment: "Online",     year: 2023, revenue: 21}
+];
+
+export const StackOrderByValue = Template.bind({});
+StackOrderByValue.args = {
+  data: revenueByYear,
+  groupBy: "segment",
+  stacked: true,
+  stackOrder: "descending",
+  x: "year",
+  y: "revenue"
+};
+StackOrderByValue.parameters = {controls: {include: ["stackOrder"]}, docs: {description: {story: "`stackOrder` accepts named value orders that rank series by their summed total. `\"descending\"` (the default) anchors the largest series — Enterprise — on the baseline with the smallest on top; switch to `\"ascending\"` to flip that and put the largest on top. Unlike the old alphabetical default, this reads by magnitude and works the same whether `x` is a string or a number (see [#527](https://github.com/d3plus/d3plus/issues/527))."}}};
+
+export const StackOrderByField = Template.bind({});
+StackOrderByField.args = {
+  data: [
+    {product: "Widgets", quarter: "Q1", units: 50, profit:  5},
+    {product: "Widgets", quarter: "Q2", units: 60, profit:  6},
+    {product: "Gadgets", quarter: "Q1", units: 20, profit: 40},
+    {product: "Gadgets", quarter: "Q2", units: 25, profit: 50},
+    {product: "Gizmos",  quarter: "Q1", units: 35, profit: 15},
+    {product: "Gizmos",  quarter: "Q2", units: 30, profit: 18}
+  ],
+  groupBy: "product",
+  stacked: true,
+  stackOrder: funcify(d => d.profit, "d => d.profit"),
+  x: "quarter",
+  y: "units"
+};
+StackOrderByField.parameters = {controls: {include: ["stackOrder"]}, docs: {description: {story: "Pass an accessor (or a `{value, order}` config) to order the stack by *any* field, not just the plotted one. Here bar height is `units`, but the stack is ordered by total `profit` — so low-volume, high-profit Gadgets sinks to the baseline while the tall Widgets band rides on top. Series are ranked by the summed accessor value, descending by default; use `{value: \"profit\", order: \"ascending\"}` to reverse."}}};

--- a/packages/docs/packages/core/charts/StackedArea.stories.jsx
+++ b/packages/docs/packages/core/charts/StackedArea.stories.jsx
@@ -107,3 +107,21 @@ SortingAreas.args = {
   y: "y"
 };
 SortingAreas.parameters = {controls: {include: ["stackOrder"]}, docs: {description: {story: "Pass an explicit array to `stackOrder` to fix the bottom-to-top stacking sequence of the series rather than letting d3plus derive it."}}};
+
+const streamData = [4, 5, 6, 7, 8, 9].flatMap(x => [
+  {id: "alpha", x, y: 12 + 8 * Math.sin(x)},
+  {id: "beta",  x, y: 18 + 6 * Math.cos(x)},
+  {id: "gamma", x, y: 10 + 5 * Math.sin(x + 1)},
+  {id: "delta", x, y: 14 + 7 * Math.cos(x + 2)}
+]);
+
+export const Streamgraph = Template.bind({});
+Streamgraph.args = {
+  data: streamData,
+  groupBy: "id",
+  stackOffset: "silhouette",
+  stackOrder: "insideOut",
+  x: "x",
+  y: "y"
+};
+Streamgraph.parameters = {controls: {include: ["stackOrder", "stackOffset"]}, docs: {description: {story: "Combine a named order with a named offset for a streamgraph: `stackOrder: \"insideOut\"` keeps the largest series in the middle and pushes late-rising ones to the edges, while `stackOffset: \"silhouette\"` centers the stack around a free baseline instead of anchoring at zero. `stackOrder` also accepts d3's `\"appearance\"` and `\"reverse\"`; `stackOffset` also accepts `\"wiggle\"` (minimizes slope changes) and `\"expand\"`."}}};


### PR DESCRIPTION
## Summary

Reworks Plot stack ordering so charts can order stacked series **by magnitude** and **by any data field** — the core ask in #527 ("sort … with higher values on top"), which the old API couldn't express.

Previously `stackOrder("ascending"|"descending")` *sounded* value-based but sorted **alphabetically by series key** (using the summed value only as a tie-break), so ordering-by-value was unavailable. Unknown order/offset names silently resolved to `undefined` and changed or broke the layout with no warning.

## What changed

All ordering now flows through a single `resolveStackOrder` / `resolveStackOffset` in `stackHelpers.ts`:

- **Value orders** — `"ascending"` / `"descending"` order by summed value (d3-aligned). `"descending"` (largest total on the baseline) is the **new default**.
- **Key orders** — the old alphabetical behavior moves to `"key"` / `"keyReverse"`.
- **Field ordering** — pass a value accessor (`d => d.profit`) or a `{value, order}` config to rank series by an aggregate of *any* field, not just the plotted one.
- **Input order** — `"none"` / `"data"` now honor input order (dropped the old `stackOrderNone → alphabetical` coercion in `pipelineDomains.ts`).
- **Still supported** — explicit `string[]` order and d3's `"insideOut"` / `"appearance"` / `"reverse"`. The resolver is reset-safe (already-resolved comparators pass back through `config()`).
- **Validation** — unknown named strings `console.warn` and fall back to a sensible default (`"descending"` / `"diverging"`) instead of failing silently.

`D3plusConfig` types widened + documented for both `stackOrder` and `stackOffset` (the latter was previously untyped).

## ⚠️ Breaking

`stackOrder("ascending"|"descending")` now orders by summed value instead of alphabetically, and the **default** changed from alphabetical to largest-total-on-baseline. Charts relying on the old default should set `stackOrder("key")` for identical output. Flagging for version gating — `main` is currently at 4.1.0.

## Storybook

- **BarChart** — `StackOrderByValue` (named value order, over an integer year axis), `StackOrderByField` (order by total `profit` while bars show `units`).
- **StackedArea** — `Streamgraph` (`insideOut` order + `silhouette` offset).

## Tests

- Rewrote `stackHelpers-test.js` for the new semantics (value/key/field orders, resolver validation, offset resolution).
- Added `stackOrdering-test.js` — drives the real format → axis-values → initial-domains pipeline to pin #527: custom order honored with an **integer x**, identical order for integer vs. string x, finite coordinates, and largest-total series anchored at the baseline by default.

Full core suite: **213 passing** (incl. visual/render-parity snapshots — unchanged; the `stacked-area` baseline's data happens to order identically under the new default). `tsc` and eslint clean.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)