### PR TITLE
fix: shape backgroundImage sizing, clipping, cover/contain + enter fade (#757)

### DIFF
--- a/packages/core/src/shapes/Image.ts
+++ b/packages/core/src/shapes/Image.ts
@@ -182,9 +182,8 @@ export default class Image {
   /**
       Compute-mode scene emission. Mirrors Shape.toScene's shape — a
       keyed GroupNode wrapping per-datum ImageNodes. Used by chart
-      compositors (Shape._backgroundImageClass, plotPaint) that need
-      Image to participate in the scene graph rather than emit
-      d3-selection DOM.
+      compositors (e.g. plotPaint) that need Image to participate in the
+      scene graph rather than emit d3-selection DOM.
   */
   toScene(): GroupNode {
     const children: SceneNode[] = (this._data || []).map(

--- a/packages/core/src/shapes/Shape.ts
+++ b/packages/core/src/shapes/Shape.ts
@@ -51,14 +51,19 @@ export interface ShapeAes {
 }
 
 
-import Image from "./Image.js";
-import {emitBackgroundImages, sortRanks} from "./sceneSort.js";
+import {
+  backgroundImageLayout,
+  emitBackgroundImages,
+  sortRanks,
+  type BackgroundImageSpec,
+} from "./sceneSort.js";
 
 /** Shape's fluent accessor schema. Config storage lives on `this.schema.<key>`. */
 const shapeSchema: ConfigField[] = [
   {key: "activeOpacity", coerce: "identity", default: 0.25},
   {key: "ariaLabel", coerce: "const", default: constant("")},
   {key: "backgroundImage", coerce: "const", default: constant(false)},
+  {key: "backgroundImageFit", coerce: "const", default: constant("cover")},
   {key: "discrete", coerce: "identity"},
   {key: "duration", coerce: "identity", default: 600},
   {key: "fill", coerce: "const", default: constant("black")},
@@ -107,7 +112,6 @@ export default class Shape extends BaseClass {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 
-  _backgroundImageClass: Image;
   _data: DataPoint[];
   _labelClass: TextBox;
   _name: string;
@@ -136,7 +140,6 @@ export default class Shape extends BaseClass {
 
     installFluent(this, shapeSchema);
 
-    this._backgroundImageClass = new Image();
     this._data = [];
     this._labelClass = new TextBox();
     this._name = "Shape";
@@ -421,10 +424,10 @@ export default class Shape extends BaseClass {
     if (this._dataFilter)
       data = this._dataFilter(data) as DataPoint[] & {key?: AccessorFn};
     const children: SceneNode[] = [];
-    // Build the backgroundImage data for emission below. Each datum that
-    // resolves to a non-false `backgroundImage(d, i)` becomes an
-    // ImageNode positioned at the shape's geometry.
-    const imageData: DataPoint[] = [];
+    // Collected background images, emitted below (after the geometry) as clipped,
+    // transformed groups. Each datum whose `backgroundImage(d, i)` resolves to a
+    // truthy URL contributes one spec.
+    const bgSpecs: BackgroundImageSpec[] = [];
     // A `sort` comparator becomes per-datum `z` ranks rather than a reorder of
     // `data`: the render backends sort each group's children ascending by `z`
     // (stably), so a lower rank paints first (behind) and a higher rank paints
@@ -465,46 +468,47 @@ export default class Shape extends BaseClass {
         },
         ...(rank ? {z: rank[i]} : {}),
       } as unknown as SceneNode);
-      // backgroundImage: collect a per-datum image when the accessor
-      // returns a truthy URL. The image is sized to the shape's
-      // geometry (preferring width/height fields when present).
+      // backgroundImage: collect a per-datum image (see backgroundImageLayout for
+      // the cover/contain fit). The wrapping group carries the shape transform,
+      // so the image box + clip stay in local space.
       const bg = this._nestWrapper(this.schema.backgroundImage)(d, i) as
         | string
         | false;
       if (bg) {
         const g = geom as Record<string, unknown>;
-        // Shape geometry is origin-centered; its on-screen position lives in
-        // the node transform. The background image is emitted as a flat sibling
-        // (no transform), so bake the shape's translate into the image x/y —
-        // otherwise every image lands at the origin (top-left).
-        const t = this._sceneTransform(d, i) as {x?: number; y?: number};
-        const w = typeof g.width === "number" ? g.width : undefined;
-        const h = typeof g.height === "number" ? g.height : undefined;
-        const cx = typeof g.cx === "number" ? g.cx : (typeof g.x === "number" ? g.x : 0);
-        const cy = typeof g.cy === "number" ? g.cy : (typeof g.y === "number" ? g.y : 0);
-        const r = typeof g.r === "number" ? g.r : undefined;
-        const iw = w ?? (r != null ? r * 2 : 0);
-        const ih = h ?? (r != null ? r * 2 : 0);
-        imageData.push({
-          __d3plus__: true,
-          data: d,
-          i,
-          id: this._nestWrapper(this.schema.id)(d, i),
-          url: bg,
-          x: (t.x ?? 0) + (cx as number) - iw / 2,
-          y: (t.y ?? 0) + (cy as number) - ih / 2,
-          width: iw,
-          height: ih,
-        } as unknown as DataPoint);
+        // Only Area/Line lack a `d`/box and need polygon points; Path/Rect/Circle
+        // derive their layout from `d`/width/r directly.
+        const needsPoints =
+          typeof g.d !== "string" &&
+          typeof g.width !== "number" &&
+          typeof g.r !== "number";
+        const points = needsPoints
+          ? ((this._aes(d, i).points ?? []) as [number, number][])
+          : [];
+        const fit = this._nestWrapper(this.schema.backgroundImageFit)(d, i);
+        const layout = backgroundImageLayout(
+          g, points, fit === "contain" ? "contain" : "cover",
+        );
+        if (layout) {
+          bgSpecs.push({
+            key,
+            index: i,
+            datum,
+            url: bg,
+            box: layout.box,
+            clip: layout.clip,
+            preserveAspectRatio: layout.preserveAspectRatio,
+            opacity: numOrUndef(this._nestWrapper(this.schema.opacity)(d, i)),
+            transform,
+          });
+        }
       }
     });
     // Emit background images AFTER shape children so they paint above the
     // shape's fill — matches the DOM order where the <image> was
     // appended as a sibling of the shape.
-    if (imageData.length)
-      children.push(
-        ...emitBackgroundImages(this._backgroundImageClass, imageData, rank, data.length),
-      );
+    if (bgSpecs.length)
+      children.push(...emitBackgroundImages(bgSpecs, rank, data.length));
     // NOTE: Labels are NOT pushed here. The canonical aggregation point is
     // `emitHelpers.collectComputed(shape)`, which appends `shape.toScene()`
     // AND `shape._labelClass.toScene()` independently. Pushing labels here

--- a/packages/core/src/shapes/sceneSort.ts
+++ b/packages/core/src/shapes/sceneSort.ts
@@ -1,7 +1,33 @@
 import type {DataPoint} from "@d3plus/data";
-import type {SceneNode} from "@d3plus/render";
+import {largestRect, path2polygon, pathBounds} from "@d3plus/math";
+import type {ClipShape, GroupNode, ImageNode, SceneNode, Transform} from "@d3plus/render";
 
-import type Image from "./Image.js";
+/** How a backgroundImage fits its shape: `cover` fills the bounding box (cropping
+    the overflow, clipped to the shape); `contain` fits the whole image, centered
+    and fully visible, inside the shape's largest inscribed rectangle. */
+export type BackgroundImageFit = "cover" | "contain";
+
+/** A per-datum background image collected during `Shape.toScene`, before it is
+    emitted as a clipped, transformed group by {@link emitBackgroundImages}. */
+export interface BackgroundImageSpec {
+  key: string | number;
+  index: number;
+  /** The source datum, carried so hover/active dimming treats the image like its
+      shape (dims + raises together). */
+  datum?: DataPoint;
+  /** The image URL. */
+  url: string;
+  /** The image box in the shape's LOCAL coordinate space (pre-transform). */
+  box: {x: number; y: number; width: number; height: number};
+  /** The shape's own geometry as a clip region (local space), or undefined. */
+  clip?: ClipShape;
+  /** SVG `preserveAspectRatio` — `slice` (cover) or `meet` (contain). */
+  preserveAspectRatio: string;
+  /** The shape's resolved node opacity — the fade-in target on enter (default 1). */
+  opacity?: number;
+  /** The shape's transform, carried on the wrapping group. */
+  transform?: Transform;
+}
 
 /** Follows the chart (`__d3plus__`) and shape (`__d3plusShape__`) wrappers back
     to the source datum, so a `sort` comparator sees the same object the other
@@ -32,31 +58,209 @@ export function sortRanks(
   return rank;
 }
 
+/** Bounding box of a list of polygon points, or null when degenerate. */
+function pointsBox(
+  points: [number, number][],
+): {x: number; y: number; width: number; height: number} | null {
+  if (!points.length) return null;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const [px, py] of points) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+  if (!Number.isFinite(minX) || maxX <= minX || maxY <= minY) return null;
+  return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
+}
+
 /**
-    Renders the per-datum background images collected during `Shape.toScene` as
-    flat sibling nodes. When `rank` is set (a `sort` comparator is active) every
-    returned node needs a `z` — otherwise the backend sort would collapse the
-    images to 0 and interleave them among the geometry — so they are placed
-    above all geometry (ranks span `0..dataLen-1`) while keeping their own order.
+    The local-space bounding box `{x, y, width, height}` a backgroundImage fills,
+    derived from a datum's scene geometry. Rect/Bar geometry is already a box;
+    Circle is centered at (cx, cy) with radius r; a `path` uses the exact
+    (DOM-free) bounds of its `d`; Area/Line fall back to their polygon `points`.
+    Returns null when no finite extent can be determined.
+*/
+export function backgroundImageBox(
+  g: Record<string, unknown>,
+  points: [number, number][],
+): {x: number; y: number; width: number; height: number} | null {
+  if (typeof g.width === "number" && typeof g.height === "number") {
+    const x = typeof g.x === "number" ? g.x : -g.width / 2;
+    const y = typeof g.y === "number" ? g.y : -g.height / 2;
+    return {x, y, width: g.width, height: g.height};
+  }
+  if (typeof g.r === "number") {
+    const cx = typeof g.cx === "number" ? g.cx : 0;
+    const cy = typeof g.cy === "number" ? g.cy : 0;
+    return {x: cx - g.r, y: cy - g.r, width: g.r * 2, height: g.r * 2};
+  }
+  if (typeof g.d === "string") {
+    const b = pathBounds(g.d);
+    return b.width > 0 && b.height > 0 ? b : null;
+  }
+  return pointsBox(points);
+}
+
+/** Rounded-rectangle path `d` (falls back to a plain rect when radii are 0). */
+function roundedRectPath(
+  x: number, y: number, w: number, h: number, rx: number, ry: number,
+): string {
+  rx = Math.min(rx, w / 2);
+  ry = Math.min(ry, h / 2);
+  return (
+    `M${x + rx},${y}h${w - 2 * rx}a${rx},${ry} 0 0 1 ${rx},${ry}` +
+    `v${h - 2 * ry}a${rx},${ry} 0 0 1 ${-rx},${ry}h${-(w - 2 * rx)}` +
+    `a${rx},${ry} 0 0 1 ${-rx},${-ry}v${-(h - 2 * ry)}a${rx},${ry} 0 0 1 ${rx},${-ry}Z`
+  );
+}
+
+/**
+    The shape's own geometry expressed as a clip region in its LOCAL coordinate
+    space, so a background image can be clipped to the shape itself (a Path image
+    is clipped to the path, a Circle image to the circle, etc.). Returns
+    undefined when the geometry has no usable outline.
+*/
+export function backgroundImageClip(
+  g: Record<string, unknown>,
+  points: [number, number][],
+): ClipShape | undefined {
+  if (typeof g.d === "string") return {type: "path", d: g.d};
+  if (typeof g.width === "number" && typeof g.height === "number") {
+    const x = typeof g.x === "number" ? g.x : -g.width / 2;
+    const y = typeof g.y === "number" ? g.y : -g.height / 2;
+    const rx = typeof g.rx === "number" ? g.rx : 0;
+    const ry = typeof g.ry === "number" ? g.ry : 0;
+    return rx > 0 || ry > 0
+      ? {type: "path", d: roundedRectPath(x, y, g.width, g.height, rx || ry, ry || rx)}
+      : {type: "rect", x, y, width: g.width, height: g.height};
+  }
+  if (typeof g.r === "number") {
+    const cx = typeof g.cx === "number" ? g.cx : 0;
+    const cy = typeof g.cy === "number" ? g.cy : 0;
+    const r = g.r;
+    return {
+      type: "path",
+      d: `M${cx - r},${cy}a${r},${r} 0 1,0 ${2 * r},0a${r},${r} 0 1,0 ${-2 * r},0Z`,
+    };
+  }
+  if (points.length > 2) {
+    const d = `M${points.map(([x, y]) => `${x},${y}`).join("L")}Z`;
+    return {type: "path", d};
+  }
+  return undefined;
+}
+
+/** A polygon (local coords) approximating the shape outline, for `largestRect`. */
+function shapePolygon(
+  g: Record<string, unknown>,
+  points: [number, number][],
+): [number, number][] {
+  if (typeof g.d === "string") return path2polygon(g.d);
+  return points;
+}
+
+/**
+    Resolves a backgroundImage's box + clip + `preserveAspectRatio` for a datum's
+    geometry, honoring the fit mode:
+
+    - `cover` — the image fills the shape's bounding box and is cropped
+      (`xMidYMid slice`), clipped to the shape's own outline.
+    - `contain` — the whole image is centered and fully visible inside the shape:
+      it is fit (`xMidYMid meet`) into the shape's largest inscribed axis-aligned
+      rectangle (a Rect uses itself; a Circle its inscribed square; a Path/Area
+      uses `largestRect` of its polygon). No clip is needed since the box already
+      sits inside the shape.
+
+    Returns null when no usable box can be derived.
+*/
+export function backgroundImageLayout(
+  g: Record<string, unknown>,
+  points: [number, number][],
+  fit: BackgroundImageFit,
+): {
+  box: {x: number; y: number; width: number; height: number};
+  clip?: ClipShape;
+  preserveAspectRatio: string;
+} | null {
+  if (fit !== "contain") {
+    const box = backgroundImageBox(g, points);
+    if (!box) return null;
+    return {
+      box,
+      clip: backgroundImageClip(g, points),
+      preserveAspectRatio: "xMidYMid slice",
+    };
+  }
+
+  // contain: fit inside the largest inscribed rectangle, fully visible.
+  let box: {x: number; y: number; width: number; height: number} | null = null;
+  if (typeof g.width === "number" && typeof g.height === "number") {
+    box = backgroundImageBox(g, points); // a rect contains itself
+  } else if (typeof g.r === "number") {
+    // Inscribed square of a circle: side = r·√2, centered on (cx, cy).
+    const cx = typeof g.cx === "number" ? g.cx : 0;
+    const cy = typeof g.cy === "number" ? g.cy : 0;
+    const half = (g.r as number) / Math.SQRT2;
+    box = {x: cx - half, y: cy - half, width: half * 2, height: half * 2};
+  } else {
+    const poly = shapePolygon(g, points);
+    const r = poly.length > 2 ? largestRect(poly, {angle: 0}) : null;
+    box = r
+      ? {x: r.cx - r.width / 2, y: r.cy - r.height / 2, width: r.width, height: r.height}
+      : backgroundImageBox(g, points);
+  }
+  return box ? {box, preserveAspectRatio: "xMidYMid meet"} : null;
+}
+
+/**
+    Emits the per-datum background images collected during `Shape.toScene`. Each
+    image is wrapped in its own group carrying the shape's datum + transform, so
+    it is clipped to the shape's outline, positioned in local space, and dims/
+    raises together with its shape on hover. The image is non-interactive (and
+    keyed apart from the shape) so pointer events pass through to the shape below.
+    When `rank` is set (a `sort` comparator is active) every group needs a `z`
+    so the backend sort keeps images above the geometry in their own order.
 */
 export function emitBackgroundImages(
-  bgClass: Image,
-  imageData: DataPoint[],
+  specs: BackgroundImageSpec[],
   rank: number[] | null,
   dataLen: number,
 ): SceneNode[] {
-  bgClass
-    .data(imageData)
-    .id((d: DataPoint) => `${(d as Record<string, unknown>).id}`)
-    .url((d: DataPoint) => (d as Record<string, unknown>).url as string)
-    .x((d: DataPoint) => (d as Record<string, unknown>).x as number)
-    .y((d: DataPoint) => (d as Record<string, unknown>).y as number)
-    .width((d: DataPoint) => (d as Record<string, unknown>).width as number)
-    .height((d: DataPoint) => (d as Record<string, unknown>).height as number)
-    .renderMode("compute");
-  const imgScene = bgClass.toScene();
-  if (!imgScene || !Array.isArray(imgScene.children)) return [];
-  if (rank)
-    imgScene.children.forEach((c, k) => ((c as SceneNode).z = dataLen + k));
-  return imgScene.children;
+  return specs.map((spec, k) => {
+    const image: ImageNode = {
+      type: "image",
+      // Keyed apart from the shape (which uses `spec.key`): sharing the key would
+      // let this non-interactive image overwrite the shape in the hit-test index.
+      key: `${spec.key}-bgimage-img`,
+      x: spec.box.x,
+      y: spec.box.y,
+      width: spec.box.width,
+      height: spec.box.height,
+      href: spec.url,
+      preserveAspectRatio: spec.preserveAspectRatio,
+      // Decorative: pointer events fall through to the shape underneath.
+      interactive: false,
+    };
+    const group: GroupNode = {
+      type: "group",
+      key: `${spec.key}-bgimage`,
+      children: [image],
+      // Carry the shape's datum/index so hover/active dimming treats the image
+      // like its shape — dimming and hover-raising the two together (the group
+      // is emitted after the geometry, so at equal `z` the image stays on top).
+      datum: spec.datum,
+      index: spec.index,
+      interactive: false,
+      // A group-level opacity gives the enter/exit animation a target to fade
+      // to/from (matching the shape): the animate layer collapses it to 0 on
+      // enter and eases up to this. It also cascades to the image, so hover
+      // dimming applied here fades the picture with its shape.
+      paint: {opacity: spec.opacity ?? 1},
+      ...(spec.transform ? {transform: spec.transform} : {}),
+      ...(spec.clip ? {clip: spec.clip} : {}),
+      ...(rank ? {z: dataLen + k} : {}),
+    };
+    return group;
+  });
 }

--- a/packages/core/src/shapes/shapeConfig.ts
+++ b/packages/core/src/shapes/shapeConfig.ts
@@ -59,6 +59,13 @@ export interface BaseShapeConfig {
   ariaLabel?: ConstOrAccessor<string>;
   /** Optional background image per datum (url or accessor returning a url). */
   backgroundImage?: ConstOrAccessor<string>;
+  /**
+      How a `backgroundImage` fits its shape: `"cover"` (default) fills the
+      shape's bounding box, cropping the overflow and clipping to the outline;
+      `"contain"` fits the whole image, centered and fully visible, inside the
+      shape's largest inscribed rectangle.
+  */
+  backgroundImageFit?: ConstOrAccessor<"cover" | "contain">;
 
   /** Discrete-axis key ("x" | "y") for charts that flip layout per axis. */
   discrete?: "x" | "y";

--- a/packages/core/test/shapes/backgroundImage-test.js
+++ b/packages/core/test/shapes/backgroundImage-test.js
@@ -1,0 +1,115 @@
+import assert from "assert";
+import {Circle, Path, Rect} from "../../es/index.js";
+
+// Finds the shape geometry node, wrapping group + inner <image> for a shape's
+// background image.
+function bgImage(shape) {
+  let group = null, image = null, shapeNode = null;
+  const MARKS = new Set(["rect", "circle", "path", "area", "line"]);
+  const walk = n => {
+    if (!n) return;
+    if (n.type === "image") image = n;
+    else if (n.type === "group" && String(n.key).endsWith("-bgimage")) group = n;
+    else if (MARKS.has(n.type)) shapeNode = n;
+    if (Array.isArray(n.children)) n.children.forEach(walk);
+  };
+  walk(shape.toScene());
+  return {group, image, shapeNode};
+}
+
+const URL = "data:image/svg+xml,%3Csvg/%3E";
+
+// Regression for #757: a Path has no width/height/cx/cy/r in its geometry, so the
+// background image used to be emitted 0×0 at (0,0) — invisible, wrong corner. It
+// should fill the path's exact (DOM-free) bounding box, clipped to the path.
+it("Path backgroundImage fills the path's exact bounds, clipped to the path (#757)", () => {
+  const diamond = "M320,40 L440,160 L320,280 L200,160 Z"; // exact bbox [200,440]×[40,280]
+  const {group, image} = bgImage(new Path().data([{id: "a", path: diamond}]).backgroundImage(URL));
+
+  assert.ok(image, "a background image node is emitted");
+  assert.deepStrictEqual(
+    {x: image.x, y: image.y, width: image.width, height: image.height},
+    {x: 200, y: 40, width: 240, height: 240},
+    "image fills the diamond's exact bounding box",
+  );
+  assert.strictEqual(image.preserveAspectRatio, "xMidYMid slice", "cover sizing");
+  assert.strictEqual(image.interactive, false, "decorative: no pointer capture");
+  assert.deepStrictEqual(group.clip, {type: "path", d: diamond}, "clipped to the path itself");
+});
+
+// Regression: the background image must not steal the shape's hit-testing. It
+// (a) keys apart from the shape so it can't overwrite it in the pick index, and
+// (b) is non-interactive; the wrapping group carries the shape's datum so hover
+// dimming/raising treats the two as one unit.
+it("background image keys apart from its shape and carries the shape datum", () => {
+  const {group, image, shapeNode} = bgImage(
+    new Path().data([{id: "a", path: "M0,0 L10,0 L10,10 L0,10 Z"}]).backgroundImage(URL),
+  );
+  assert.notStrictEqual(String(image.key), String(shapeNode.key), "image key ≠ shape key");
+  assert.strictEqual(String(shapeNode.key), "a", "shape keeps its own key");
+  assert.strictEqual(image.interactive, false);
+  assert.strictEqual(group.interactive, false);
+  assert.ok(group.datum && group.datum.id === "a", "group carries the shape datum for dimming");
+  assert.strictEqual(group.index, 0);
+  // A defined group opacity is the enter/exit fade target (collapse → 0 → this),
+  // matching how shapes fade in.
+  assert.strictEqual(group.paint && group.paint.opacity, 1, "group carries a fade-in opacity target");
+});
+
+// contain fit: the image is fit (meet) inside the shape's largest inscribed
+// rectangle, fully visible, and NOT clipped.
+it("backgroundImageFit 'contain' fits inside the inscribed rect, unclipped", () => {
+  // Circle → inscribed square (side = r·√2), centered on the origin.
+  const {group, image} = bgImage(
+    new Circle().data([{id: "a", x: 250, y: 150, r: 60}])
+      .backgroundImage(URL).backgroundImageFit("contain"),
+  );
+  assert.strictEqual(image.preserveAspectRatio, "xMidYMid meet", "contain sizing");
+  assert.strictEqual(group.clip, undefined, "contain does not clip (image is inside the shape)");
+  const side = 60 * Math.SQRT2;
+  assert.ok(Math.abs(image.width - side) < 1e-6 && Math.abs(image.height - side) < 1e-6,
+    "fit to the inscribed square");
+  assert.ok(Math.abs((image.x + image.width / 2)) < 1e-6, "centered on the circle (local origin)");
+
+  // Path diamond → an inner box strictly smaller than the 240×240 bbox.
+  const {image: dImg} = bgImage(
+    new Path().data([{id: "a", path: "M320,40 L440,160 L320,280 L200,160 Z"}])
+      .backgroundImage(URL).backgroundImageFit("contain"),
+  );
+  assert.ok(dImg.width < 240 && dImg.height < 240, "inner rect smaller than the bbox");
+  assert.ok(dImg.width > 80 && dImg.height > 80, "but a substantial inscribed rect");
+});
+
+// The image must cover the rect and be positioned by the group transform, not
+// half a box up-and-left of it (the pre-fix corner-as-center bug).
+it("Rect backgroundImage covers the rect and is clipped to it", () => {
+  const {group, image} = bgImage(
+    new Rect().data([{id: "a", x: 250, y: 150, width: 120, height: 80}]).backgroundImage(URL),
+  );
+  // Local box centered on origin; the group transform places it at (250,150).
+  assert.deepStrictEqual(
+    {x: image.x, y: image.y, width: image.width, height: image.height},
+    {x: -60, y: -40, width: 120, height: 80},
+    "image box is the rect in local space",
+  );
+  assert.strictEqual(group.transform.x, 250);
+  assert.strictEqual(group.transform.y, 150);
+  // Absolute coverage = transform + box → spans the rect [190,310]×[110,190].
+  assert.strictEqual(group.transform.x + image.x, 190);
+  assert.strictEqual(group.transform.y + image.y, 110);
+  assert.deepStrictEqual(group.clip, {type: "rect", x: -60, y: -40, width: 120, height: 80});
+});
+
+// Circle already positioned correctly; pin the clip (a circle path) + cover.
+it("Circle backgroundImage covers the circle and is clipped to it", () => {
+  const {group, image} = bgImage(
+    new Circle().data([{id: "a", x: 250, y: 150, r: 60}]).backgroundImage(URL),
+  );
+  assert.deepStrictEqual(
+    {x: image.x, y: image.y, width: image.width, height: image.height},
+    {x: -60, y: -60, width: 120, height: 120},
+    "image box is the circle's square in local space",
+  );
+  assert.strictEqual(group.clip.type, "path", "circle clipped via a path region");
+  assert.ok(/^M-60,0a60,60 /.test(group.clip.d), "clip is a radius-60 circle path");
+});

--- a/packages/docs/packages/core/charts/StackedArea.stories.jsx
+++ b/packages/docs/packages/core/charts/StackedArea.stories.jsx
@@ -27,6 +27,13 @@ const Template = (args) => <StackedArea config={configify(args, argTypes)} />;
 
 import {formatAbbreviate} from "@d3plus/format";
 
+// Two inline-SVG icons used by the ShapeBackgroundImages example below. The
+// `viewBox` is what preserves each icon's aspect ratio when it is scaled to fit
+// a band (an SVG with no viewBox has no intrinsic aspect ratio, so the browser
+// would stretch it).
+const starIcon = "data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cpolygon%20points%3D%2250%2C4%2061%2C38%2098%2C38%2068%2C59%2079%2C95%2050%2C73%2021%2C95%2032%2C59%202%2C38%2039%2C38%22%20fill%3D%22%230b6e63%22%2F%3E%3C%2Fsvg%3E";
+const heartIcon = "data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cpath%20d%3D%22M50%2C88%20C10%2C58%2020%2C18%2050%2C42%20C80%2C18%2090%2C58%2050%2C88%20Z%22%20fill%3D%22%23c0392b%22%2F%3E%3C%2Fsvg%3E";
+
 export const BasicExample = Template.bind({});
 BasicExample.args = {
   data: [
@@ -84,6 +91,37 @@ SharePercentages.args = {
   }
 };
 SharePercentages.parameters = {controls: {include: ["stackOffset", "yConfig"]}, docs: {description: {story: "Set `stackOffset: \"expand\"` to normalize every `x` position to 100%, turning the chart into a share-of-total view; `yConfig.tickFormat` then labels the axis as percentages."}}};
+
+export const ShapeBackgroundImages = Template.bind({});
+ShapeBackgroundImages.args = {
+  data: [
+    {id: "alpha", x: 4, y: 12},
+    {id: "alpha", x: 5, y: 28},
+    {id: "alpha", x: 6, y: 20},
+    {id: "beta",  x: 4, y: 22},
+    {id: "beta",  x: 5, y: 14},
+    {id: "beta",  x: 6, y: 24}
+  ],
+  groupBy: "id",
+  x: "x",
+  y: "y",
+  shapeConfig: {
+    Area: {
+      // `backgroundImageFit: "contain"` fits the whole icon inside each band's
+      // largest inscribed rectangle — centered and completely visible. (The
+      // default, "cover", instead fills the band's bounding box and clips to its
+      // outline.) The image's aspect ratio is always preserved.
+      backgroundImageFit: "contain",
+      backgroundImage: funcify(
+        d => (d.id === "alpha" ? starIcon : heartIcon),
+        `const starIcon = "${starIcon}";\n` +
+        `const heartIcon = "${heartIcon}";\n` +
+        `d => d.id === "alpha" ? starIcon : heartIcon`
+      )
+    }
+  }
+};
+ShapeBackgroundImages.parameters = {controls: {include: ["shapeConfig"]}, docs: {description: {story: "Set `shapeConfig.Area.backgroundImage` to a per-series URL to place an image on each stacked band. Here `backgroundImageFit: \"contain\"` fits each icon inside the band's largest inscribed rectangle — centered, fully visible, and aspect-preserved. Omit `backgroundImageFit` (or set `\"cover\"`) to instead fill the band's bounding box and clip the image to the band's outline."}}};
 
 export const SortingAreas = Template.bind({});
 SortingAreas.args = {

--- a/packages/docs/packages/core/shapes/Path.stories.jsx
+++ b/packages/docs/packages/core/shapes/Path.stories.jsx
@@ -35,3 +35,19 @@ BasicExample.args = {
   fill: "none", stroke: "#cc4b4b", strokeWidth: 4
 };
 BasicExample.parameters = {controls: {include: ["d"]}, docs: {description: {story: "The `d` accessor reads a raw SVG path string from each datum; with `fill: none` and a `stroke`, the cubic-Bezier path renders as an open curved stroke."}}};
+
+export const BackgroundImage = Template.bind({});
+BackgroundImage.args = {
+  // A diamond whose exact bounding box is the 240×240 square [200,440]×[40,280].
+  data: [
+    {id: "diamond", path: "M320,40 L440,160 L320,280 L200,160 Z"}
+  ],
+  fill: "#7fb3d5", stroke: "#2c3e50", strokeWidth: 2,
+  // The `backgroundImage` accessor returns a per-datum URL. A Path has no
+  // width/height of its own, so the image fills the path's exact (DOM-free)
+  // bounding box using `cover` and is clipped to the path itself — here a wide
+  // 400×200 "landscape" is cover-cropped to the square bbox and shows only
+  // through the diamond. (The `viewBox` keeps the image's aspect ratio when scaled.)
+  backgroundImage: "data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20400%20200%22%20width%3D%22400%22%20height%3D%22200%22%3E%3Crect%20width%3D%22400%22%20height%3D%22200%22%20fill%3D%22%239ad0ec%22%2F%3E%3Ccircle%20cx%3D%22320%22%20cy%3D%2255%22%20r%3D%2228%22%20fill%3D%22%23ffd93b%22%2F%3E%3Crect%20y%3D%22150%22%20width%3D%22400%22%20height%3D%2250%22%20fill%3D%22%236ab04c%22%2F%3E%3Cpolygon%20points%3D%220%2C150%2090%2C80%20180%2C150%22%20fill%3D%22%233d7a3d%22%2F%3E%3Cpolygon%20points%3D%22140%2C150%20240%2C60%20340%2C150%22%20fill%3D%22%234c9a4c%22%2F%3E%3C%2Fsvg%3E"
+};
+BackgroundImage.parameters = {controls: {include: ["backgroundImage"]}, docs: {description: {story: "Setting `backgroundImage` to a per-datum URL fills each path with an image. A Path carries no width/height, so the image is sized to the path's exact bounding box (computed DOM-free from the `d` string), scaled to `cover` that box, and clipped to the path outline — so the landscape appears only inside the diamond (see issue #757)."}}};

--- a/packages/math/index.ts
+++ b/packages/math/index.ts
@@ -3,6 +3,7 @@ export {default as closest} from "./src/closest.js";
 export {default as largestRect} from "./src/largestRect.js";
 export {default as lineIntersection} from "./src/lineIntersection.js";
 export {default as path2polygon} from "./src/path2polygon.js";
+export {default as pathBounds} from "./src/pathBounds.js";
 export {default as pointDistance} from "./src/pointDistance.js";
 export {default as pointDistanceSquared} from "./src/pointDistanceSquared.js";
 export {default as pointRotate} from "./src/pointRotate.js";

--- a/packages/math/src/path2polygon.ts
+++ b/packages/math/src/path2polygon.ts
@@ -1,26 +1,89 @@
 import type {Point} from "./lineIntersection.js";
+import parsePath, {arcPoint, arcToCenter} from "./pathParse.js";
+
+/** Chord-length of a cubic Bézier's control polygon — an upper bound on its arc length. */
+function cubicPolyLen(
+  x0: number, y0: number, x1: number, y1: number,
+  x2: number, y2: number, x3: number, y3: number,
+): number {
+  return (
+    Math.hypot(x1 - x0, y1 - y0) +
+    Math.hypot(x2 - x1, y2 - y1) +
+    Math.hypot(x3 - x2, y3 - y2)
+  );
+}
 
 /**
-    Transforms a path string into an Array of points.
+    Transforms a path string into an Array of points, with no DOM involved.
+    Straight segments contribute their endpoints; curves and arcs are flattened
+    into line segments no longer than `segmentLength`. Higher `segmentLength`
+    values lower computation time but yield more rigid curves.
     @param path An SVG string path, commonly the "d" property of a <path> element.
-    @param segmentLength The length of line segments when converting curves line segments. Higher values lower computation time, but will result in curves that are more rigid.
+    @param segmentLength The maximum length of line segments when flattening curves.
 */
-export default function (path: string, segmentLength: number = 50): Point[] {
-  if (typeof document === "undefined") return [];
-
-  const svgPath = document.createElementNS(
-    "http://www.w3.org/2000/svg",
-    "path",
-  );
-  svgPath.setAttribute("d", path);
-
-  const len = svgPath.getTotalLength();
-  const NUM_POINTS = len / segmentLength < 10 ? len / 10 : len / segmentLength;
-
+export default function path2polygon(
+  path: string,
+  segmentLength: number = 50,
+): Point[] {
   const points: Point[] = [];
-  for (let i = 0; i < NUM_POINTS; i++) {
-    const pt = svgPath.getPointAtLength((i * len) / (NUM_POINTS - 1));
-    points.push([pt.x, pt.y]);
+  const step = Math.max(1, segmentLength);
+  let cx = 0, cy = 0;
+
+  const push = (x: number, y: number): void => {
+    const last = points[points.length - 1];
+    // Skip exact duplicates (e.g. a curve start == the previous endpoint).
+    if (!last || last[0] !== x || last[1] !== y) points.push([x, y]);
+  };
+
+  for (const seg of parsePath(path)) {
+    if (seg.type === "M" || seg.type === "L") {
+      push(seg.x, seg.y);
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "C") {
+      const len = cubicPolyLen(cx, cy, seg.x1, seg.y1, seg.x2, seg.y2, seg.x, seg.y);
+      const n = Math.max(2, Math.ceil(len / step));
+      for (let i = 1; i <= n; i++) {
+        const t = i / n, u = 1 - t;
+        push(
+          u * u * u * cx + 3 * u * u * t * seg.x1 + 3 * u * t * t * seg.x2 + t * t * t * seg.x,
+          u * u * u * cy + 3 * u * u * t * seg.y1 + 3 * u * t * t * seg.y2 + t * t * t * seg.y,
+        );
+      }
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "Q") {
+      const len =
+        Math.hypot(seg.x1 - cx, seg.y1 - cy) + Math.hypot(seg.x - seg.x1, seg.y - seg.y1);
+      const n = Math.max(2, Math.ceil(len / step));
+      for (let i = 1; i <= n; i++) {
+        const t = i / n, u = 1 - t;
+        push(
+          u * u * cx + 2 * u * t * seg.x1 + t * t * seg.x,
+          u * u * cy + 2 * u * t * seg.y1 + t * t * seg.y,
+        );
+      }
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "A") {
+      const arc = arcToCenter(
+        cx, cy, seg.rx, seg.ry, seg.rot, seg.large, seg.sweep, seg.x, seg.y,
+      );
+      if (!arc) {
+        push(seg.x, seg.y);
+      } else {
+        // Estimate length from the average radius × swept angle.
+        const len = ((arc.rx + arc.ry) / 2) * Math.abs(arc.dtheta);
+        const n = Math.max(2, Math.ceil(len / step));
+        for (let i = 1; i <= n; i++) {
+          const [px, py] = arcPoint(arc, arc.theta1 + (arc.dtheta * i) / n);
+          push(px, py);
+        }
+      }
+      cx = seg.x;
+      cy = seg.y;
+    }
+    // Z contributes no new vertex — the subpath start is already in `points`.
   }
 
   return points;

--- a/packages/math/src/pathBounds.ts
+++ b/packages/math/src/pathBounds.ts
@@ -1,0 +1,130 @@
+import parsePath, {arcPoint, arcToCenter} from "./pathParse.js";
+
+/** Value of a cubic Bézier on one axis at parameter t. */
+function cubicAt(p0: number, p1: number, p2: number, p3: number, t: number): number {
+  const u = 1 - t;
+  return u * u * u * p0 + 3 * u * u * t * p1 + 3 * u * t * t * p2 + t * t * t * p3;
+}
+
+/** Value of a quadratic Bézier on one axis at parameter t. */
+function quadAt(p0: number, p1: number, p2: number, t: number): number {
+  const u = 1 - t;
+  return u * u * p0 + 2 * u * t * p1 + t * t * p2;
+}
+
+/** Parameters in (0,1) where a cubic Bézier's derivative is zero on one axis. */
+function cubicExtrema(p0: number, p1: number, p2: number, p3: number): number[] {
+  const a = p3 - 3 * p2 + 3 * p1 - p0;
+  const b = 2 * (p2 - 2 * p1 + p0);
+  const c = p1 - p0;
+  const ts: number[] = [];
+  if (Math.abs(a) < 1e-12) {
+    if (Math.abs(b) > 1e-12) ts.push(-c / b);
+  } else {
+    const disc = b * b - 4 * a * c;
+    if (disc >= 0) {
+      const s = Math.sqrt(disc);
+      ts.push((-b + s) / (2 * a), (-b - s) / (2 * a));
+    }
+  }
+  return ts.filter(t => t > 0 && t < 1);
+}
+
+/** Parameter in (0,1) where a quadratic Bézier's derivative is zero on one axis. */
+function quadExtremum(p0: number, p1: number, p2: number): number[] {
+  const den = p0 - 2 * p1 + p2;
+  if (Math.abs(den) < 1e-12) return [];
+  const t = (p0 - p1) / den;
+  return t > 0 && t < 1 ? [t] : [];
+}
+
+/** True when absolute ellipse angle `theta` falls inside the arc's signed sweep. */
+function angleInArc(theta: number, theta1: number, dtheta: number): boolean {
+  const TAU = 2 * Math.PI;
+  let d = theta - theta1;
+  if (dtheta >= 0) {
+    while (d < 0) d += TAU;
+    while (d > TAU) d -= TAU;
+    return d <= dtheta + 1e-9;
+  }
+  while (d > 0) d -= TAU;
+  while (d < -TAU) d += TAU;
+  return d >= dtheta - 1e-9;
+}
+
+/**
+    Computes the exact bounding box of an SVG path string with no DOM involved,
+    evaluating the true extrema of each Bézier and arc segment (not a sampled
+    approximation). Returns `{x, y, width, height}`, or a zero-size box at the
+    origin for an empty/unparseable path.
+    @param d An SVG path string (the `d` attribute of a `<path>`).
+*/
+export default function pathBounds(d: string): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const add = (x: number, y: number): void => {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  };
+
+  let cx = 0, cy = 0;
+  for (const seg of parsePath(d)) {
+    if (seg.type === "M" || seg.type === "L") {
+      add(seg.x, seg.y);
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "C") {
+      add(cx, cy);
+      add(seg.x, seg.y);
+      // At each axis extremum, include the full point on the curve — only the
+      // extreme axis grows the box, the other coordinate is a real point on it.
+      const ts = [
+        ...cubicExtrema(cx, seg.x1, seg.x2, seg.x),
+        ...cubicExtrema(cy, seg.y1, seg.y2, seg.y),
+      ];
+      for (const t of ts)
+        add(cubicAt(cx, seg.x1, seg.x2, seg.x, t), cubicAt(cy, seg.y1, seg.y2, seg.y, t));
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "Q") {
+      add(cx, cy);
+      add(seg.x, seg.y);
+      const ts = [...quadExtremum(cx, seg.x1, seg.x), ...quadExtremum(cy, seg.y1, seg.y)];
+      for (const t of ts)
+        add(quadAt(cx, seg.x1, seg.x, t), quadAt(cy, seg.y1, seg.y, t));
+      cx = seg.x;
+      cy = seg.y;
+    } else if (seg.type === "A") {
+      add(cx, cy);
+      add(seg.x, seg.y);
+      const arc = arcToCenter(
+        cx, cy, seg.rx, seg.ry, seg.rot, seg.large, seg.sweep, seg.x, seg.y,
+      );
+      if (arc) {
+        const {phi, rx, ry, theta1, dtheta} = arc;
+        // Ellipse-angle candidates where dX/dθ = 0 and dY/dθ = 0.
+        const cands = [
+          Math.atan2(-ry * Math.sin(phi), rx * Math.cos(phi)),
+          Math.atan2(ry * Math.cos(phi), rx * Math.sin(phi)),
+        ];
+        for (const base of cands)
+          for (const theta of [base, base + Math.PI])
+            if (angleInArc(theta, theta1, dtheta)) {
+              const [px, py] = arcPoint(arc, theta);
+              add(px, py);
+            }
+      }
+      cx = seg.x;
+      cy = seg.y;
+    }
+  }
+
+  if (!Number.isFinite(minX)) return {x: 0, y: 0, width: 0, height: 0};
+  return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
+}

--- a/packages/math/src/pathParse.ts
+++ b/packages/math/src/pathParse.ts
@@ -1,0 +1,270 @@
+import type {Point} from "./lineIntersection.js";
+
+/**
+    A path segment normalized to absolute coordinates. The parser folds away all
+    of SVG's shorthand — relative commands, `H`/`V`, the smooth `S`/`T` reflections
+    — so downstream consumers only ever see absolute `M`/`L`/`C`/`Q`/`A`/`Z`.
+*/
+export type PathSegment =
+  | {type: "M" | "L"; x: number; y: number}
+  | {type: "C"; x1: number; y1: number; x2: number; y2: number; x: number; y: number}
+  | {type: "Q"; x1: number; y1: number; x: number; y: number}
+  | {
+      type: "A";
+      rx: number;
+      ry: number;
+      rot: number;
+      large: number;
+      sweep: number;
+      x: number;
+      y: number;
+    }
+  | {type: "Z"};
+
+const WS = new Set([" ", "\t", "\n", "\r", "\f", ","]);
+
+/**
+    A pointer-driven scanner over an SVG path `d` string. Kept command-aware so
+    it can read arc flags (`large-arc`/`sweep`) as single `0`/`1` characters even
+    when they are glued to the next number (the classic `a5 5 0 0150 0` case a
+    plain number regex mis-tokenizes).
+    @private
+*/
+class Scanner {
+  s: string;
+  i = 0;
+  constructor(s: string) {
+    this.s = s;
+  }
+  eof(): boolean {
+    return this.i >= this.s.length;
+  }
+  skipSep(): void {
+    while (this.i < this.s.length && WS.has(this.s[this.i])) this.i++;
+  }
+  /** Reads a number token (handles `.5`, `1.`, `1e3`, signs, exponents). */
+  readNumber(): number {
+    this.skipSep();
+    const start = this.i;
+    const s = this.s;
+    if (s[this.i] === "+" || s[this.i] === "-") this.i++;
+    while (this.i < s.length && s[this.i] >= "0" && s[this.i] <= "9") this.i++;
+    if (s[this.i] === ".") {
+      this.i++;
+      while (this.i < s.length && s[this.i] >= "0" && s[this.i] <= "9") this.i++;
+    }
+    if (s[this.i] === "e" || s[this.i] === "E") {
+      this.i++;
+      if (s[this.i] === "+" || s[this.i] === "-") this.i++;
+      while (this.i < s.length && s[this.i] >= "0" && s[this.i] <= "9") this.i++;
+    }
+    return parseFloat(s.slice(start, this.i));
+  }
+  /** Reads a single `0`/`1` arc flag, which may be glued to the next number. */
+  readFlag(): number {
+    this.skipSep();
+    const c = this.s[this.i];
+    this.i++;
+    return c === "1" ? 1 : 0;
+  }
+  /** True when the next non-separator char begins a new number (implicit repeat). */
+  moreArgs(): boolean {
+    this.skipSep();
+    const c = this.s[this.i];
+    return (
+      c !== undefined &&
+      (c === "+" || c === "-" || c === "." || (c >= "0" && c <= "9"))
+    );
+  }
+  nextCommand(): string | null {
+    this.skipSep();
+    const c = this.s[this.i];
+    if (c !== undefined && ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z"))) {
+      this.i++;
+      return c;
+    }
+    return null;
+  }
+}
+
+/**
+    Parses an SVG path `d` string into a flat list of absolute {@link PathSegment}s,
+    with no DOM involved. Every relative command is resolved against the running
+    point, `H`/`V` become `L`, and `S`/`T` expand into `C`/`Q` using the reflected
+    previous control point.
+    @param d An SVG path string (the `d` attribute of a `<path>`).
+*/
+export default function parsePath(d: string): PathSegment[] {
+  const out: PathSegment[] = [];
+  if (!d) return out;
+  const sc = new Scanner(d);
+  let cmd: string | null = null;
+  let cx = 0, cy = 0; // current point
+  let sx = 0, sy = 0; // subpath start (for Z)
+  // Reflected control point of the previous C/S (cubic) or Q/T (quadratic).
+  let px = 0, py = 0;
+  let prevType = "";
+
+  while (!sc.eof()) {
+    const next = sc.nextCommand();
+    if (next) cmd = next;
+    else if (cmd === null) break;
+    // Implicit repeats: a repeated M/m draws L/l; everything else repeats itself.
+    else if (cmd === "M") cmd = "L";
+    else if (cmd === "m") cmd = "l";
+    const rel = cmd === (cmd as string).toLowerCase();
+    const C = (cmd as string).toUpperCase();
+    const bx = rel ? cx : 0;
+    const by = rel ? cy : 0;
+
+    if (C === "M") {
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      sx = cx;
+      sy = cy;
+      out.push({type: "M", x: cx, y: cy});
+    } else if (C === "L") {
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "L", x: cx, y: cy});
+    } else if (C === "H") {
+      cx = sc.readNumber() + bx;
+      out.push({type: "L", x: cx, y: cy});
+    } else if (C === "V") {
+      cy = sc.readNumber() + by;
+      out.push({type: "L", x: cx, y: cy});
+    } else if (C === "C") {
+      const x1 = sc.readNumber() + bx, y1 = sc.readNumber() + by;
+      const x2 = sc.readNumber() + bx, y2 = sc.readNumber() + by;
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "C", x1, y1, x2, y2, x: cx, y: cy});
+      px = x2;
+      py = y2;
+    } else if (C === "S") {
+      const ref = prevType === "C" || prevType === "S";
+      const x1 = ref ? 2 * cx - px : cx, y1 = ref ? 2 * cy - py : cy;
+      const x2 = sc.readNumber() + bx, y2 = sc.readNumber() + by;
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "C", x1, y1, x2, y2, x: cx, y: cy});
+      px = x2;
+      py = y2;
+    } else if (C === "Q") {
+      const x1 = sc.readNumber() + bx, y1 = sc.readNumber() + by;
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "Q", x1, y1, x: cx, y: cy});
+      px = x1;
+      py = y1;
+    } else if (C === "T") {
+      const ref = prevType === "Q" || prevType === "T";
+      const x1 = ref ? 2 * cx - px : cx, y1 = ref ? 2 * cy - py : cy;
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "Q", x1, y1, x: cx, y: cy});
+      px = x1;
+      py = y1;
+    } else if (C === "A") {
+      const rx = sc.readNumber(), ry = sc.readNumber(), rot = sc.readNumber();
+      const large = sc.readFlag(), sweep = sc.readFlag();
+      cx = sc.readNumber() + bx;
+      cy = sc.readNumber() + by;
+      out.push({type: "A", rx, ry, rot, large, sweep, x: cx, y: cy});
+    } else if (C === "Z") {
+      out.push({type: "Z"});
+      cx = sx;
+      cy = sy;
+    } else {
+      // Unknown command — bail rather than loop forever.
+      break;
+    }
+    prevType = C;
+    // Stop repeating this command once its arguments are exhausted.
+    if (C !== "Z" && !sc.moreArgs()) {
+      // leave cmd set so an implicit repeat is only taken when numbers follow
+    }
+  }
+  return out;
+}
+
+/**
+    Converts an SVG endpoint-parameterized arc to its center parameterization
+    (SVG spec F.6.5), returning the ellipse center, corrected radii, x-axis
+    rotation (radians), start angle and signed sweep. Returns null for a
+    degenerate arc (zero radius), which callers treat as a straight line.
+    @private
+*/
+export function arcToCenter(
+  x1: number,
+  y1: number,
+  rx: number,
+  ry: number,
+  rotDeg: number,
+  large: number,
+  sweep: number,
+  x2: number,
+  y2: number,
+): {
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+  phi: number;
+  theta1: number;
+  dtheta: number;
+} | null {
+  rx = Math.abs(rx);
+  ry = Math.abs(ry);
+  if (rx === 0 || ry === 0) return null;
+  const phi = (rotDeg * Math.PI) / 180;
+  const cosP = Math.cos(phi), sinP = Math.sin(phi);
+  const dx = (x1 - x2) / 2, dy = (y1 - y2) / 2;
+  const x1p = cosP * dx + sinP * dy;
+  const y1p = -sinP * dx + cosP * dy;
+  // Scale radii up if they are too small to span the endpoints.
+  const lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+  if (lambda > 1) {
+    const s = Math.sqrt(lambda);
+    rx *= s;
+    ry *= s;
+  }
+  const sign = large !== sweep ? 1 : -1;
+  const num = rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p;
+  const den = rx * rx * y1p * y1p + ry * ry * x1p * x1p;
+  const co = sign * Math.sqrt(Math.max(0, num / den));
+  const cxp = (co * rx * y1p) / ry;
+  const cyp = (-co * ry * x1p) / rx;
+  const cx = cosP * cxp - sinP * cyp + (x1 + x2) / 2;
+  const cy = sinP * cxp + cosP * cyp + (y1 + y2) / 2;
+  const ang = (ux: number, uy: number, vx: number, vy: number): number => {
+    const dot = ux * vx + uy * vy;
+    const len = Math.sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
+    let a = Math.acos(Math.min(1, Math.max(-1, dot / len)));
+    if (ux * vy - uy * vx < 0) a = -a;
+    return a;
+  };
+  const theta1 = ang(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry);
+  let dtheta = ang(
+    (x1p - cxp) / rx,
+    (y1p - cyp) / ry,
+    (-x1p - cxp) / rx,
+    (-y1p - cyp) / ry,
+  );
+  if (!sweep && dtheta > 0) dtheta -= 2 * Math.PI;
+  else if (sweep && dtheta < 0) dtheta += 2 * Math.PI;
+  return {cx, cy, rx, ry, phi, theta1, dtheta};
+}
+
+/** A point on a center-parameterized arc at absolute ellipse angle `theta`. */
+export function arcPoint(
+  arc: {cx: number; cy: number; rx: number; ry: number; phi: number},
+  theta: number,
+): Point {
+  const cosP = Math.cos(arc.phi), sinP = Math.sin(arc.phi);
+  const ct = Math.cos(theta), st = Math.sin(theta);
+  return [
+    arc.cx + arc.rx * ct * cosP - arc.ry * st * sinP,
+    arc.cy + arc.rx * ct * sinP + arc.ry * st * cosP,
+  ];
+}

--- a/packages/math/test/pathBounds-test.js
+++ b/packages/math/test/pathBounds-test.js
@@ -1,0 +1,44 @@
+import assert from "assert";
+import {pathBounds, path2polygon} from "../es/index.js";
+
+const near = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
+const boxNear = (got, exp, eps = 1e-4) =>
+  near(got.x, exp.x, eps) && near(got.y, exp.y, eps) &&
+  near(got.width, exp.width, eps) && near(got.height, exp.height, eps);
+
+it("math/pathBounds computes exact bounds with no DOM", () => {
+  // Straight lines / relative / H+V.
+  assert.ok(boxNear(pathBounds("M320,40 L440,160 L320,280 L200,160 Z"),
+    {x: 200, y: 40, width: 240, height: 240}), "diamond");
+  assert.ok(boxNear(pathBounds("m10,10 h100 v50 h-100 z"),
+    {x: 10, y: 10, width: 100, height: 50}), "relative H/V rect");
+
+  // Cubic Bézier: bounds come from the curve extrema, tighter than the hull.
+  const cubic = pathBounds("M0,0 C0,100 100,100 100,0");
+  assert.ok(near(cubic.x, 0) && near(cubic.width, 100), "cubic x extent = endpoints");
+  // Peak of this symmetric cubic is 3/4 of the control height (75), not 100.
+  assert.ok(near(cubic.y, 0) && near(cubic.height, 75, 1e-6), "cubic y extent from extrema");
+
+  // Full-circle drawn as two arcs → tight square bounds.
+  assert.ok(boxNear(pathBounds("M100,50 a50,50 0 1,0 100,0 a50,50 0 1,0 -100,0 Z"),
+    {x: 100, y: 0, width: 100, height: 100}, 1e-3), "circle via arcs");
+
+  // Arc flags glued to the next number must still parse.
+  const glued = pathBounds("M80,80 A40 40 0 0180 160 Z");
+  assert.ok(glued.width > 0 && glued.height > 0, "glued arc flags parse");
+});
+
+it("math/path2polygon is DOM-free and returns real points", () => {
+  // The old implementation returned [] without a document; this must not.
+  const poly = path2polygon("M0,0 L100,0 L100,100 L0,100 Z");
+  assert.ok(poly.length >= 4, "polygon has the rectangle's vertices");
+  const xs = poly.map(p => p[0]), ys = poly.map(p => p[1]);
+  assert.strictEqual(Math.min(...xs), 0);
+  assert.strictEqual(Math.max(...xs), 100);
+  assert.strictEqual(Math.min(...ys), 0);
+  assert.strictEqual(Math.max(...ys), 100);
+
+  // Curves are flattened densely enough to approximate the shape.
+  const arc = path2polygon("M100,50 a50,50 0 1,0 100,0 a50,50 0 1,0 -100,0 Z", 8);
+  assert.ok(arc.length > 20, "arc flattened into many segments");
+});

--- a/packages/render/src/canvas/CanvasRenderer.ts
+++ b/packages/render/src/canvas/CanvasRenderer.ts
@@ -424,7 +424,27 @@ export default class CanvasRenderer implements Renderer {
     }
     if (img.complete && img.naturalWidth) {
       ctx.globalAlpha = alpha;
-      ctx.drawImage(img, node.x, node.y, node.width, node.height);
+      const par = node.preserveAspectRatio;
+      const iw = img.naturalWidth, ih = img.naturalHeight;
+      if (par && par.includes("slice")) {
+        // CSS `cover`: scale the image to fill the box, cropping the overflow
+        // (centered), via drawImage's source-rect crop.
+        const scale = Math.max(node.width / iw, node.height / ih);
+        const sw = node.width / scale, sh = node.height / scale;
+        ctx.drawImage(
+          img, (iw - sw) / 2, (ih - sh) / 2, sw, sh,
+          node.x, node.y, node.width, node.height,
+        );
+      } else if (par && par !== "none" && par.includes("meet")) {
+        // CSS `contain`: fit the whole image inside the box (centered).
+        const scale = Math.min(node.width / iw, node.height / ih);
+        const dw = iw * scale, dh = ih * scale;
+        ctx.drawImage(
+          img, node.x + (node.width - dw) / 2, node.y + (node.height - dh) / 2, dw, dh,
+        );
+      } else {
+        ctx.drawImage(img, node.x, node.y, node.width, node.height);
+      }
     }
   }
 

--- a/packages/render/src/scene.ts
+++ b/packages/render/src/scene.ts
@@ -263,6 +263,14 @@ export interface ImageNode extends NodeBase {
   width: number;
   height: number;
   href: string;
+  /**
+      SVG `preserveAspectRatio` value controlling how the image fits its
+      `width`×`height` box. Passed straight through by the SVG backend; the
+      Canvas backend honors the `meet`/`slice`/`none` mode (slice = CSS
+      `cover`, meet = `contain`, none = stretch). Omitted = the SVG default
+      (`xMidYMid meet`, i.e. contain).
+  */
+  preserveAspectRatio?: string;
 }
 
 /** A single laid-out line of text within a TextNode. */

--- a/packages/render/src/svg/svgNodeAttrs.ts
+++ b/packages/render/src/svg/svgNodeAttrs.ts
@@ -265,7 +265,8 @@ export function applyGeometry(
         .attr("x", node.x)
         .attr("y", node.y)
         .attr("width", node.width)
-        .attr("height", node.height);
+        .attr("height", node.height)
+        .attr("preserveAspectRatio", node.preserveAspectRatio ?? null);
       break;
     case "text":
       target.attr("x", node.x).attr("y", node.y);


### PR DESCRIPTION
Closes #757.

## Problem

`backgroundImage` on a shape was broken for **Path** (and Area/Line): the scene emitter sized/positioned images from `width`/`height`/`cx`/`cy`/`r` fields that path geometry doesn't have, so every image collapsed to **0×0 at the origin** — invisible and pinned to the top-left. **Rect/Bar** were also offset by half their size (the formula treated the geometry's top-left corner as its center; only Circle, whose `cx`/`cy` is a true center, worked).

## What changed

**Correct sizing + exact, DOM-free path bounds**
- Box is now computed per geometry: Rect/Bar from `width`/`height`, Circle from `cx`/`cy`/`r`, Path from exact path bounds, Area/Line from their polygon.
- New in `@d3plus/math`: a DOM-free SVG path parser (`pathParse`, handles every command incl. arcs and glued flags), a `pathBounds` export computing **exact** bounds from Bézier/arc extrema (validated to <0.03px vs the browser's `getBBox`), and a DOM-free rewrite of `path2polygon` — which also makes **Pie labels work in SSR/Node** (the old `getTotalLength` path returned `[]` without a DOM).

**Clip to the shape + cover/contain**
- Each image is emitted in its own **clipped, transformed group**: clipped to the shape's own outline (path / rect / rounded-rect / circle / area polygon), positioned by the shape transform.
- New `ImageNode.preserveAspectRatio` + `shapeConfig.backgroundImageFit`:
  - `"cover"` (default) — fills the bounding box (cropped), clipped to the shape.
  - `"contain"` — fits the image, centered and fully visible, inside the shape's **largest inscribed rectangle** (`largestRect`).
  - Aspect ratio is preserved in both modes. SVG passes `preserveAspectRatio` through; Canvas implements cover/contain/stretch in `drawImage`.

**Interaction — images behave as part of their shape**
- Keyed apart from the shape (so the non-interactive image can't overwrite the shape in the hit-test index → pointer events reach the shape and tooltips fire).
- The wrapping group carries the shape's `datum`, so hover/active **dimming** and the hover **z-raise** apply to the image together with its shape (the highlight no longer paints over the image).
- The group carries a paint opacity, so background images **fade in/out on enter/exit** exactly like shapes.

## Docs
- Path → **BackgroundImage** (cover, clipped to the path).
- StackedArea → **ShapeBackgroundImages** (the two prior examples merged; `contain` icons). Example inline SVGs now carry a `viewBox` so their aspect ratio is preserved.

## Verification
- New regression tests: `pathBounds`/`path2polygon` exactness + DOM-free; backgroundImage sizing, clipping, `contain`, key/datum wiring, and the fade-in opacity target.
- Suites green: core **210**, math **25**, render **48**; `tsc` + lint clean across math/render/core.
- Real-browser (headless Chromium) checks: exact bounds, clip + cover applied, pointer-events pass through to the shape, hover raise/dim of shape + image together, and enter fade — the area and its background image fade `0.05 → 0.60 → 0.99 → 1` in lockstep.

Note: `Shape.render()` standalone snaps (it never threaded a duration); enter animation happens in the Viz render path, which is where shapes animate too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XojqX18QxpnbE4VkQC9jeg