### PR TITLE
fix: filter non-plottable (NaN/null) values out of Plot data (#776)

### DIFF
--- a/packages/core/src/charts/Plot/pipeline.ts
+++ b/packages/core/src/charts/Plot/pipeline.ts
@@ -39,12 +39,39 @@ const defaultChartFeatures = [
   totalFeature,
 ];
 
+/**
+    A plotted axis value that can't be turned into a pixel coordinate: a
+    non-finite number (`NaN`/`±Infinity`), `null`, or the empty-array sentinel
+    `merge` yields when a numeric column aggregates to no usable value. Any of
+    these poisons the shape's transform or path `d` downstream — e.g.
+    `translate(NaN,…)` or `…L268.75,NaN` — which the browser rejects. A bare
+    `undefined` is NOT bad: it's how an unused secondary axis (x2/y2) reports
+    "no value on this row".
+*/
+const isBadAxisValue = (v: unknown): boolean =>
+  v === null ||
+  (typeof v === "number" && !Number.isFinite(v)) ||
+  (Array.isArray(v) && v.length === 0);
+
+/**
+    A formatted row is plottable when its x/y — and any *defined* x2/y2 — are
+    real coordinates. Rows failing this are dropped in `formatPlotData` before
+    domains, stacking, and paint ever read `_formattedData`, so a NaN measure
+    no longer widens a domain, stacks as 0, or emits a broken coordinate.
+    Resolves d3plus/d3plus#776.
+*/
+const isPlottableRow = (d: Record<string, unknown>): boolean =>
+  !isBadAxisValue(d.x) &&
+  !isBadAxisValue(d.y) &&
+  (d.x2 === undefined || !isBadAxisValue(d.x2)) &&
+  (d.y2 === undefined || !isBadAxisValue(d.y2));
 
 /**
     `formatPlotData` — first stage of Plot's chart-specific pipeline. Detects
     time axes (sets viz._xTime / _x2Time / _yTime / _y2Time), maps the
     filtered data through `prepData` to produce the per-row PlotDatum shape
-    (x/y/x2/y2 + id + group + shape + lci/hci + discrete), and constructs
+    (x/y/x2/y2 + id + group + shape + lci/hci + discrete), drops rows whose
+    axis values can't be plotted (`isPlottableRow` — see #776), and constructs
     the `_sizeScaleD3` if `_size` is set.
 
     Pure compute. Returns `{formattedData, axisData, x2Exists, y2Exists}`
@@ -107,8 +134,12 @@ export const formatPlotData: TransformStage = ({viz}) => {
     return newD;
   };
 
-  const formattedData = (viz._formattedData = viz._filteredData.map(prepData));
-  const axisData = viz._axisPersist ? viz._data.map(prepData) : formattedData;
+  const formattedData = (viz._formattedData = viz._filteredData
+    .map(prepData)
+    .filter(isPlottableRow));
+  const axisData = viz._axisPersist
+    ? viz._data.map(prepData).filter(isPlottableRow)
+    : formattedData;
 
   if (viz._size) {
     const rExtent = extent(axisData, (d: Record<string, unknown>) =>

--- a/packages/core/test/charts/plot-nan-test.js
+++ b/packages/core/test/charts/plot-nan-test.js
@@ -1,0 +1,134 @@
+import assert from "assert";
+import it from "../jsdom.js";
+import {BarChart, LinePlot, Plot} from "../../es/index.js";
+import {runStages} from "../../es/internal.js";
+import {
+  computePlotAxisValues,
+  computePlotInitialDomains,
+  computePlotScales,
+  formatPlotData,
+} from "../../es/src/charts/Plot/pipeline.js";
+
+/**
+    Regression coverage for d3plus/d3plus#776 — a `NaN` (or `null`, or the
+    empty-array sentinel `merge` yields for an all-NaN numeric aggregate) on a
+    Plot axis used to survive into the shape layer. On the aggregated path it
+    coerced to 0 (a phantom bar/point at the baseline); on the raw-leaves Line
+    path (base `Plot` with `shape: "Line"` and no `discrete`) it reached the
+    line generator and emitted `…L268.75,NaN`, which the browser rejects with
+    `<path> attribute d: Expected number`.
+
+    `formatPlotData` now filters non-plottable rows out of `_formattedData`
+    before any downstream stage reads it, so the offending point is dropped
+    rather than mis-plotted. Each case below drives the data→scale stage chain
+    and asserts (a) the bad row is gone from the formatted data and (b) every
+    plotted coordinate is a finite number.
+*/
+
+function pipeline(viz) {
+  viz._preDraw();
+  viz._margin = {top: 0, right: 0, bottom: 0, left: 0};
+  return runStages({viz}, [
+    formatPlotData,
+    computePlotAxisValues,
+    computePlotInitialDomains,
+    computePlotScales,
+  ]);
+}
+
+/** Every x/y pixel coordinate the shape layer would scale from this row set. */
+function pixelCoords(ctx) {
+  const {x, y} = ctx.plotScales;
+  return ctx.plotFormattedData.flatMap(d => [x(d.x), y(d.y)]);
+}
+
+const scenarios = [
+  {
+    name: "base Plot + Line shape, no discrete (raw-leaves path)",
+    build: () =>
+      new Plot()
+        .groupBy("id")
+        .shape(() => "Line")
+        .data([
+          {value: 10, id: "alpha", q: 1},
+          {value: 30, id: "alpha", q: 2},
+          {value: 50, id: "alpha", q: 3},
+          {value: 20, id: "beta", q: 1},
+          {value: 40, id: "beta", q: 2},
+          {value: NaN, id: "beta", q: 3},
+        ]),
+    keptRows: 5,
+  },
+  {
+    name: "LinePlot with a NaN measure",
+    build: () =>
+      new LinePlot()
+        .groupBy("id")
+        .data([
+          {value: 10, id: "alpha", q: 1},
+          {value: 30, id: "alpha", q: 2},
+          {value: 20, id: "beta", q: 1},
+          {value: NaN, id: "beta", q: 2},
+        ]),
+    keptRows: 3,
+  },
+  {
+    name: "BarChart with a NaN measure (aggregated)",
+    build: () =>
+      new BarChart()
+        .groupBy("id")
+        .data([
+          {value: 10, id: "alpha", q: "Q1"},
+          {value: 30, id: "alpha", q: "Q2"},
+          {value: 20, id: "beta", q: "Q1"},
+          {value: NaN, id: "beta", q: "Q2"},
+        ]),
+    keptRows: 3,
+  },
+  {
+    name: "Plot scatter with a NaN measure",
+    build: () =>
+      new Plot()
+        .groupBy("id")
+        .data([
+          {value: 10, id: "a", q: 1},
+          {value: 30, id: "b", q: 2},
+          {value: NaN, id: "c", q: 3},
+        ]),
+    keptRows: 2,
+  },
+];
+
+for (const {name, build, keptRows} of scenarios) {
+  it(`#776 drops non-plottable rows: ${name}`, () => {
+    const viz = build().x(d => d.q).y("value").width(600).height(400).duration(0);
+    const ctx = pipeline(viz);
+
+    assert.strictEqual(
+      ctx.plotFormattedData.length,
+      keptRows,
+      "the NaN row should be filtered out of the formatted data",
+    );
+    const coords = pixelCoords(ctx);
+    const bad = coords.filter(c => typeof c !== "number" || !Number.isFinite(c));
+    assert.deepStrictEqual(bad, [], "every plotted coordinate is a finite number");
+  });
+}
+
+it("#776 does not drop rows when x2/y2 are legitimately undefined", () => {
+  const viz = new LinePlot()
+    .groupBy("id")
+    .data([
+      {value: 10, id: "alpha", q: 1},
+      {value: 30, id: "alpha", q: 2},
+      {value: 20, id: "beta", q: 1},
+      {value: 40, id: "beta", q: 2},
+    ])
+    .x("q")
+    .y("value")
+    .width(600)
+    .height(400)
+    .duration(0);
+  const ctx = pipeline(viz);
+  assert.strictEqual(ctx.plotFormattedData.length, 4, "all valid rows are kept");
+});


### PR DESCRIPTION
Closes #776.

## Problem

A `NaN` on a numeric Plot axis reached the shape layer. Reproduced across every Plot variant in v4.2.0:

| Chart | What happens to the NaN | Result |
|---|---|---|
| **BarChart / LinePlot** (default `discrete: "x"`) | `merge()` aggregates it into `[]`, which coerces to `0` | phantom bar/point at the baseline (silent, wrong) |
| **scatter** (`Plot` + Circle) | same → `[]` → `0` | mis-plotted at zero |
| **base `Plot` + `shape:"Line"` + no discrete** | raw un-merged leaves keep the NaN, so it reaches the line generator | **console error:** `<path> attribute d: Expected number, "…L268.75,NaN"` |

That last one is the v4 equivalent of the original `<g> attribute transform: Trailing garbage` error from the issue.

Root cause: **non-finite plotted values were never filtered out of Plot's data**, so they either crash (raw path) or silently render at zero (aggregated path).

## Fix

`formatPlotData` now drops rows whose `x`/`y` — or a *defined* `x2`/`y2` — aren't plottable (non-finite number, `null`, or the empty-array sentinel `merge` yields for an all-NaN aggregate), before domains, stacking, and paint ever read `_formattedData`. So a NaN measure no longer widens a domain, stacks as `0`, or emits a broken coordinate — the point is simply absent.

A bare `undefined` is deliberately left alone: that's how an unused secondary axis (`x2`/`y2`) reports "no value on this row", so charts without `x2`/`y2` are unaffected. This matches the maintainer's own note on the issue that the fix belongs at the visualization (Plot) level.

## Tests

- New `packages/core/test/charts/plot-nan-test.js` — 5 cases across the four Plot variants plus a guard that valid rows with `undefined` `x2`/`y2` are never dropped.
- Full core suite: **223 passing, 0 failing** (all visual-regression and pipeline-parity snapshots unchanged — normal data never trips the filter).
- `tsc --noEmit` and eslint clean.
- Verified in headless Chromium that the console error is gone and no `NaN`/`undefined` appears in any SVG `transform`/`d`/coordinate attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)